### PR TITLE
Add tests + small improvements to the CLI parsing

### DIFF
--- a/client/client.iml
+++ b/client/client.iml
@@ -4,13 +4,14 @@
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/annotations" isTestSource="false" generated="true" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Maven: io.netty:netty:3.6.6.Final" level="project" />
+    <orderEntry type="library" name="Maven: info.picocli:picocli:4.5.1" level="project" />
   </component>
 </module>

--- a/client/client.iml
+++ b/client/client.iml
@@ -7,11 +7,35 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/annotations" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter-engine:5.6.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.apiguardian:apiguardian-api:1.1.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.junit.platform:junit-platform-engine:1.6.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.opentest4j:opentest4j:1.2.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.junit.platform:junit-platform-commons:1.6.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter-api:5.6.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-core:3.5.10" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: net.bytebuddy:byte-buddy:1.10.13" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: net.bytebuddy:byte-buddy-agent:1.10.13" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.objenesis:objenesis:3.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-junit-jupiter:3.5.10" level="project" />
     <orderEntry type="library" name="Maven: io.netty:netty:3.6.6.Final" level="project" />
     <orderEntry type="library" name="Maven: info.picocli:picocli:4.5.1" level="project" />
+    <orderEntry type="module" module-name="shared" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter-engine:5.6.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.apiguardian:apiguardian-api:1.1.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.junit.platform:junit-platform-engine:1.6.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.opentest4j:opentest4j:1.2.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.junit.platform:junit-platform-commons:1.6.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter-api:5.6.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-core:3.5.10" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: net.bytebuddy:byte-buddy:1.10.13" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: net.bytebuddy:byte-buddy-agent:1.10.13" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.objenesis:objenesis:3.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-junit-jupiter:3.5.10" level="project" />
   </component>
 </module>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -29,6 +29,27 @@
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.moparforia</groupId>
+            <artifactId>shared</artifactId>
+        </dependency>
+
+        <!-- Test dependencies-->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/client/src/main/java/org/moparforia/client/Launcher.java
+++ b/client/src/main/java/org/moparforia/client/Launcher.java
@@ -119,10 +119,7 @@ public class Launcher implements Callable<Void> {
 
     @Override
     public Void call() throws Exception{
-        JFrame frame = new JFrame();
-        frame.setTitle("Minigolf");
-        Image img = loadIcon();
-        frame.setIconImage(img);
+        JFrame frame = createFrame();
         if (hostname.isEmpty() || port == 0) {
             // Determine which of these was actually false
             String temp_hostname = hostname.isEmpty() ? DEFAULT_SERVER : hostname;
@@ -134,6 +131,14 @@ public class Launcher implements Callable<Void> {
 
         launchGame(frame, hostname, port, lang, verbose);
         return null;
+    }
+
+    public JFrame createFrame() throws IOException {
+        JFrame frame = new JFrame();
+        frame.setTitle("Minigolf");
+        Image img = loadIcon();
+        frame.setIconImage(img);
+        return frame;
     }
 
     public Game launchGame(JFrame frame, String hostname, int port, Language lang, boolean verbose) {

--- a/client/src/main/java/org/moparforia/client/Launcher.java
+++ b/client/src/main/java/org/moparforia/client/Launcher.java
@@ -2,24 +2,25 @@ package org.moparforia.client;
 
 import picocli.CommandLine;
 
+import org.moparforia.shared.ManifestVersionProvider;
 import javax.imageio.ImageIO;
 import javax.swing.*;
 import java.awt.*;
+import java.io.IOException;
 import java.text.ParseException;
 import java.util.concurrent.Callable;
 
-/**
- * Playforia
- * 28.5.2013
- */
+
 @CommandLine.Command(
         description = "Starts Minigolf Client",
-        name = "client", mixinStandardHelpOptions = true
+        name = "client",
+        mixinStandardHelpOptions = true,
+        versionProvider = ManifestVersionProvider.class
 )
 public class Launcher implements Callable<Void> {
 
-    private static final String DEFAULT_SERVER = "127.0.0.1";
-    private static final int DEFAULT_PORT = 4242;
+    public static final String DEFAULT_SERVER = "127.0.0.1";
+    public static final int DEFAULT_PORT = 4242;
 
     // CLI options
     @CommandLine.Option(names = {"--hostname", "-ip"},
@@ -33,9 +34,8 @@ public class Launcher implements Callable<Void> {
     private int port;
 
     @CommandLine.Option(names = {"--lang", "-l"},
-            description = "Sets language of the game, available values: ${COMPLETION-CANDIDATES}",
-            defaultValue = "EN_US")
-    private Language lang;
+            description = "Sets language of the game, available values:\n ${COMPLETION-CANDIDATES}")
+    private Language lang = Language.EN_US;
 
     @CommandLine.Option(names = {"--verbose", "-v"}, description = "Set if you want verbose information")
     private static boolean verbose = false;
@@ -51,7 +51,9 @@ public class Launcher implements Callable<Void> {
     public static void main(String... args) throws Exception {
         Launcher launcher = new Launcher();
         try {
-            CommandLine.ParseResult parseResult = new CommandLine(launcher).parseArgs(args);
+            CommandLine.ParseResult parseResult = new CommandLine(launcher)
+                    .setCaseInsensitiveEnumValuesAllowed(true)
+                    .parseArgs(args);
             if (!CommandLine.printHelpIfRequested(parseResult)) {
                 launcher.call();
             }
@@ -61,7 +63,7 @@ public class Launcher implements Callable<Void> {
         }
     }
 
-    private boolean showSettingDialog(JFrame frame, String server, int port) throws ParseException {
+    public boolean showSettingDialog(JFrame frame, String server, int port) throws ParseException {
         JPanel pane = new JPanel();
         pane.setLayout(new GridLayout(4, 1));
 
@@ -119,7 +121,7 @@ public class Launcher implements Callable<Void> {
     public Void call() throws Exception{
         JFrame frame = new JFrame();
         frame.setTitle("Minigolf");
-        Image img = ImageIO.read(getClass().getResource("/icons/playforia.png"));
+        Image img = loadIcon();
         frame.setIconImage(img);
         if (hostname.isEmpty() || port == 0) {
             // Determine which of these was actually false
@@ -130,10 +132,25 @@ public class Launcher implements Callable<Void> {
             }
         }
 
-        new Game(frame, hostname, port, lang.toString(), verbose);
+        launchGame(frame, hostname, port, lang, verbose);
         return null;
     }
 
+    public Game launchGame(JFrame frame, String hostname, int port, Language lang, boolean verbose) {
+        return new Game(frame, hostname, port, lang.toString(), verbose);
+    }
+
+    public Image loadIcon() throws IOException {
+        return ImageIO.read(getClass().getResource("/icons/playforia.png"));
+    }
+
+    public void setHostname(String hostname) {
+        this.hostname = hostname;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
 
     enum Language {
         EN_US("en_US"),

--- a/client/src/test/java/org/moparforia/client/LauncherCLITest.java
+++ b/client/src/test/java/org/moparforia/client/LauncherCLITest.java
@@ -1,0 +1,126 @@
+package org.moparforia.client;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import picocli.CommandLine;
+
+import javax.swing.*;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.text.ParseException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests that CLI parsing works as expected, it doesn't test the main method, but it tests the picocli annotations
+ */
+@ExtendWith(MockitoExtension.class)
+class LauncherCLITest {
+
+    private Launcher launcher;
+
+    private CommandLine cmd;
+    private StringWriter stdOut;
+    private StringWriter stdErr;
+
+    @BeforeEach
+    void setUp() throws ParseException, IOException {
+        // Mock game
+        launcher = spy(new Launcher());
+        lenient().doReturn(mock(Game.class)).when(launcher).launchGame(any(JFrame.class), anyString(), anyInt(), any(), anyBoolean());
+
+        // Mock creating JFrame
+        lenient().doReturn(mock(JFrame.class)).when(launcher).createFrame();
+
+        // Mock settings dialog
+        lenient().doAnswer((invocaton) -> {
+            launcher.setPort(invocaton.getArgument(2));
+            launcher.setHostname(invocaton.getArgument(1));
+            return true;
+        }).when(launcher).showSettingDialog(any(JFrame.class), anyString(), anyInt());
+
+        cmd = new CommandLine(launcher).setCaseInsensitiveEnumValuesAllowed(true);
+
+        stdOut = new StringWriter();
+        stdErr = new StringWriter();
+
+        cmd.setOut(new PrintWriter(stdOut));
+        cmd.setErr(new PrintWriter(stdErr));
+    }
+
+    @AfterEach
+    void tearDown() {
+        clearInvocations(launcher);
+    }
+
+    @Test
+    void testInvalidPort() {
+        assertNotEquals(0, cmd.execute("-p", "test"));
+        assertNotEquals(0, cmd.execute("--port=test"));
+        assertNotEquals(0, cmd.execute("-p"));
+    }
+
+    @Test
+    void testInvalidLang() {
+        assertNotEquals(0, cmd.execute("-l", "cs_CZ"));
+        assertNotEquals(0, cmd.execute("-l", "en"));
+    }
+
+    @Test
+    void testValidLang() {
+        assertEquals(0, cmd.execute("-l", "en_US"));
+        verify(launcher).launchGame(any(),
+                eq(Launcher.DEFAULT_SERVER),
+                eq(Launcher.DEFAULT_PORT),
+                eq(Launcher.Language.EN_US),
+                anyBoolean());
+
+        assertEquals(0, cmd.execute("--lang=Fi_fI"));
+        verify(launcher).launchGame(any(),
+                eq(Launcher.DEFAULT_SERVER),
+                eq(Launcher.DEFAULT_PORT),
+                eq(Launcher.Language.FI_FI),
+                anyBoolean());
+    }
+
+    @Test
+    void testValidPortAndHostname() {
+        assertEquals(0, cmd.execute("-p", "1111", "-ip", "128.128.128.128"));
+        verify(launcher).launchGame(any(), eq("128.128.128.128"), eq(1111), any(), anyBoolean());
+
+        assertEquals(0, cmd.execute("-p=2222", "-ip=127.127.127.127"));
+        verify(launcher).launchGame(any(), eq("127.127.127.127"), eq(2222), any(), anyBoolean());
+
+        assertEquals(0, cmd.execute("-p=3333", "-ip=126.126.126.126"));
+        verify(launcher).launchGame(any(), eq("126.126.126.126"), eq(3333), any(), anyBoolean());
+    }
+
+    @Test
+    void testOnlyPort() {
+        assertEquals(0, cmd.execute("-p", "1111"));
+        verify(launcher).launchGame(any(), eq(Launcher.DEFAULT_SERVER), eq(1111), any(), anyBoolean());
+    }
+
+    @Test
+    void testOnlyHostname() {
+        assertEquals(0, cmd.execute("-ip", "127.127.127.127"));
+        verify(launcher).launchGame(any(), eq("127.127.127.127"), eq(Launcher.DEFAULT_PORT), any(), anyBoolean());
+    }
+
+    @Test
+    void testDefaultValues() {
+        assertEquals(0, cmd.execute());
+        verify(launcher).launchGame(any(),
+                eq(Launcher.DEFAULT_SERVER),
+                eq(Launcher.DEFAULT_PORT),
+                eq(Launcher.Language.EN_US),
+                eq(false));
+    }
+}

--- a/client/src/test/java/org/moparforia/client/ResourceLoadTest.java
+++ b/client/src/test/java/org/moparforia/client/ResourceLoadTest.java
@@ -1,0 +1,22 @@
+package org.moparforia.client;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+
+/**
+ * Tests that resources can be loaded
+ */
+class ResourceLoadTest {
+
+    /**
+     * Tests that Launcher icon can be loaded
+     */
+    @Test
+    void testLoadIcon() {
+        Launcher launcher = new Launcher();
+        assertDoesNotThrow(launcher::loadIcon);
+    }
+
+}

--- a/editor/editor.iml
+++ b/editor/editor.iml
@@ -4,7 +4,6 @@
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
       <excludeFolder url="file://$MODULE_DIR$/target" />

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,13 @@
                                 <transformers>
                                     <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                         <mainClass>${project.mainClass}</mainClass>
+                                        <manifestEntries>
+                                            <Specification-Title>${project.artifactId}</Specification-Title>
+                                            <Specification-Version>${project.version}</Specification-Version>
+                                            <Implementation-Title>${project.artifactId}</Implementation-Title>
+                                            <Implementation-Version>${project.version}</Implementation-Version>
+                                            <Implementation-Vendor-Id>${project.groupId}</Implementation-Vendor-Id>
+                                        </manifestEntries>
                                     </transformer>
                                 </transformers>
                             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,10 @@
                     <artifactId>exec-maven-plugin</artifactId>
                     <version>3.0.0</version>
                 </plugin>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.22.2</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
@@ -112,6 +116,26 @@
                 <groupId>info.picocli</groupId>
                 <artifactId>picocli</artifactId>
                 <version>${picocli.version}</version>
+            </dependency>
+
+            <!-- Test dependencies-->
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>5.6.2</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>3.5.10</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>3.5.10</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -40,6 +40,23 @@
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
         </dependency>
+
+        <!-- Test dependencies-->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/server/server.iml
+++ b/server/server.iml
@@ -6,6 +6,7 @@
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/annotations" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />
@@ -17,5 +18,17 @@
     <orderEntry type="library" name="Maven: com.thoughtworks.proxytoys:proxytoys:1.0" level="project" />
     <orderEntry type="module" module-name="shared" />
     <orderEntry type="library" name="Maven: info.picocli:picocli:4.5.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter-engine:5.6.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.apiguardian:apiguardian-api:1.1.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.junit.platform:junit-platform-engine:1.6.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.opentest4j:opentest4j:1.2.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.junit.platform:junit-platform-commons:1.6.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter-api:5.6.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-core:3.5.10" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: net.bytebuddy:byte-buddy:1.10.13" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: net.bytebuddy:byte-buddy-agent:1.10.13" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.objenesis:objenesis:3.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-junit-jupiter:3.5.10" level="project" />
+    <orderEntry type="module" module-name="client" scope="TEST" />
   </component>
 </module>

--- a/server/server.iml
+++ b/server/server.iml
@@ -5,6 +5,7 @@
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/annotations" isTestSource="false" generated="true" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />
@@ -15,5 +16,6 @@
     <orderEntry type="library" name="Maven: cglib:cglib-nodep:2.2.2" level="project" />
     <orderEntry type="library" name="Maven: com.thoughtworks.proxytoys:proxytoys:1.0" level="project" />
     <orderEntry type="module" module-name="shared" />
+    <orderEntry type="library" name="Maven: info.picocli:picocli:4.5.1" level="project" />
   </component>
 </module>

--- a/server/src/main/java/org/moparforia/server/Launcher.java
+++ b/server/src/main/java/org/moparforia/server/Launcher.java
@@ -1,24 +1,28 @@
 package org.moparforia.server;
 
+import org.moparforia.shared.ManifestVersionProvider;
 import picocli.CommandLine;
 
 import java.util.concurrent.Callable;
 
 @CommandLine.Command(
         description = "Starts Minigolf Server",
-        name = "server", mixinStandardHelpOptions = true
+        name = "server",
+        mixinStandardHelpOptions = true,
+        versionProvider = ManifestVersionProvider.class
 )
 public class Launcher implements Callable<Void> {
 
+    public static final String DEFAULT_HOST = "0.0.0.0";
+    public static final int DEFAULT_PORT = 4242;
+
     @CommandLine.Option(names = {"--hostname", "-ip"},
-            description = "Sets server hostname",
-            defaultValue = "0.0.0.0")
-    private String host;
+            description = "Sets server hostname")
+    private String host = DEFAULT_HOST;
 
     @CommandLine.Option(names = {"--port", "-p"},
-            description = "Sets server port",
-            defaultValue = "4242")
-    private int port;
+            description = "Sets server port")
+    private int port = DEFAULT_PORT;
 
     public static void main(String... args) {
         Launcher launcher = new Launcher();
@@ -35,7 +39,11 @@ public class Launcher implements Callable<Void> {
 
     @Override
     public Void call() {
-        new Server(host, port).start();
+        getServer(host, port).start();
         return null;
+    }
+
+    public Server getServer(String host, int port) {
+        return new Server(host, port);
     }
 }

--- a/server/src/test/java/org/moparforia/server/LauncherCLITest.java
+++ b/server/src/test/java/org/moparforia/server/LauncherCLITest.java
@@ -1,0 +1,87 @@
+package org.moparforia.server;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import picocli.CommandLine;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests that CLI parsing works as expected, it doesn't test the main method, but it tests the picocli annotations
+ */
+@ExtendWith(MockitoExtension.class)
+class LauncherCLITest {
+    private Launcher launcher;
+
+    private CommandLine cmd;
+    private StringWriter stdErr;
+    private StringWriter stdOut;
+
+    @BeforeEach
+    void setUp() {
+        // Mock Launcher instance
+        launcher = spy(new Launcher());
+        lenient().doReturn(mock(Server.class)).when(launcher).getServer(anyString(), anyInt());
+
+        cmd = new CommandLine(launcher).setCaseInsensitiveEnumValuesAllowed(true);
+
+        stdOut = new StringWriter();
+        stdErr = new StringWriter();
+
+        cmd.setOut(new PrintWriter(stdOut));
+        cmd.setErr(new PrintWriter(stdErr));
+    }
+
+    @AfterEach
+    void tearDown() {
+        clearInvocations(launcher);
+    }
+
+    @Test
+    void testInvalidPort() {
+        assertNotEquals(0, cmd.execute("-p", "test"));
+        assertNotEquals(0, cmd.execute("--port=test"));
+        assertNotEquals(0, cmd.execute("-p"));
+
+        verify(launcher, never()).getServer(anyString(), anyInt());
+    }
+
+    @Test
+    void testValidPortAndHostname() {
+        assertEquals(0, cmd.execute("-p", "1111", "-ip", "128.128.128.128"));
+        verify(launcher).getServer(eq("128.128.128.128"), eq(1111));
+
+        assertEquals(0, cmd.execute("-p=2222", "-ip=127.127.127.127"));
+        verify(launcher).getServer(eq("127.127.127.127"), eq(2222));
+
+        assertEquals(0, cmd.execute("-p=3333", "-ip=126.126.126.126"));
+        verify(launcher).getServer(eq("126.126.126.126"), eq(3333));
+    }
+
+    @Test
+    void testOnlyPort() {
+        assertEquals(0, cmd.execute("-p", "1111"));
+        verify(launcher).getServer(eq(Launcher.DEFAULT_HOST), eq(1111));
+    }
+
+    @Test
+    void testOnlyHostname() {
+        assertEquals(0, cmd.execute("-ip", "127.127.127.127"));
+        verify(launcher).getServer(eq("127.127.127.127"), eq(Launcher.DEFAULT_PORT));
+    }
+
+    @Test
+    void testDefaultValues() {
+        assertEquals(0, cmd.execute());
+        verify(launcher).getServer(eq(Launcher.DEFAULT_HOST), eq(Launcher.DEFAULT_PORT));
+    }
+}

--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -26,7 +26,6 @@
         </dependency>
     </dependencies>
     <build>
-        <sourceDirectory>src</sourceDirectory>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -24,6 +24,11 @@
             <artifactId>morphia</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/shared/shared.iml
+++ b/shared/shared.iml
@@ -13,5 +13,6 @@
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.mongodb.morphia:morphia:1.2.2" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: cglib:cglib-nodep:2.2.2" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.thoughtworks.proxytoys:proxytoys:1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: info.picocli:picocli:4.5.1" level="project" />
   </component>
 </module>

--- a/shared/src/main/java/org/moparforia/shared/ManifestVersionProvider.java
+++ b/shared/src/main/java/org/moparforia/shared/ManifestVersionProvider.java
@@ -1,0 +1,11 @@
+package org.moparforia.shared;
+
+import picocli.CommandLine;
+
+public class ManifestVersionProvider implements CommandLine.IVersionProvider {
+    @Override
+    public String[] getVersion() {
+        String version = ManifestVersionProvider.class.getPackage().getImplementationVersion();
+        return new String[] {"${COMMAND-FULL-NAME} " + version};
+    }
+}


### PR DESCRIPTION
* Small improvements to the CLI parsing.
  * Version is now read from MANIFEST files.
  * Make language selection case insensitive.
* Change Launcher classes to support test.
  * Extracting some calls into separate methods so they can be mocked
  * Make few methods and properties public so they can be tested.
     * If we had project written in a better way this would not be needed, but we are no there yet.
* Add tests
  * Using Mockito and JUnit 5.
  * Tests are automatically run on mvn install, so no changes to CI needed.
  * Currently only contains CLI tests + Icon loading test.

I am not sure how much are you familiar with JUnit 5 or testing in general, so if you didn't understand something or wanted something explained, just let me know. Same if you would like to see more test cases.
