### PR TITLE
Update Netty version to the latest 3.x release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty</artifactId> <!-- Use 'netty-all' for 4.0 or above -->
-                <version>3.6.6.Final</version>
+                <version>3.10.6.Final</version>
                 <scope>compile</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
There aren't any breaking changes and means we now have every dependency up-to-date. 

This is still risky as the entire networking depends on this, but I was able to connect to the server and play without any problems