### PR TITLE
Add Dockerfile for server docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+#
+# Build stage
+#
+FROM maven:3.6.0-jdk-8-slim AS build
+COPY . /home/app/
+RUN mvn -f /home/app/pom.xml -pl server -am clean package
+
+#
+# Package stage
+#
+FROM openjdk:8-alpine
+COPY --from=build /home/app/server/target/server-*.jar /home/minigolf/server.jar
+COPY tracks/ /home/minigolf/tracks/
+EXPOSE 4242
+WORKDIR /home/minigolf
+ENTRYPOINT ["java","-jar","server.jar"]


### PR DESCRIPTION
* Add Dockerfile to create container image for server.
  * It uses two-phase build where the first phase run mavens and second phase only runs the compiled jar.
  * I didn't add editor and client to the server because docker is not ideal for starting GUI applications, I can add them if you want them but I am not even sure if they will run on macOS (for Linux you basically have to use magic to forward all the x11 stuff).
* It has bundled tracks.

I didn't include actions yet, the reason is I would like to know which repository you would like the image to reside in.