### PR TITLE
add --norandom to client to disable shot randomization

### DIFF
--- a/client/src/main/java/agolf/game/GameCanvas.java
+++ b/client/src/main/java/agolf/game/GameCanvas.java
@@ -3,6 +3,8 @@ package agolf.game;
 import agolf.GameContainer;
 import agolf.Seed;
 import agolf.SynchronizedBool;
+
+import com.aapeli.client.Parameters;
 import com.aapeli.client.StringDraw;
 import com.aapeli.tools.Tools;
 
@@ -60,6 +62,7 @@ public class GameCanvas extends GameBackgroundCanvas implements Runnable, MouseM
     private Graphics graphics;
     private Thread aThread2842;
     private boolean aBoolean2843;
+    private boolean norandom;
 
     // aimbot stuff
     final private boolean allowCheating = false;
@@ -74,6 +77,7 @@ public class GameCanvas extends GameBackgroundCanvas implements Runnable, MouseM
         this.anInt2833 = 0;
         this.gameState = 0;
         this.anInt2839 = anInt2838;
+        this.norandom = Parameters.getBooleanValue(var1.params.getParameter("norandom"));
     }
 
     public void update(Graphics g) {
@@ -947,8 +951,10 @@ public class GameCanvas extends GameBackgroundCanvas implements Runnable, MouseM
         temp = Math.sqrt(this.speedX[playerId] * this.speedX[playerId] + this.speedY[playerId] * this.speedY[playerId]);
         double speed = temp / 6.5D;
         speed *= speed;
-        this.speedX[playerId] += speed * ((double) (this.rngSeed.next() % '\uc351') / 100000.0D - 0.25D);
-        this.speedY[playerId] += speed * ((double) (this.rngSeed.next() % '\uc351') / 100000.0D - 0.25D);
+        if (!this.norandom) {
+            this.speedX[playerId] += speed * ((double) (this.rngSeed.next() % '\uc351') / 100000.0D - 0.25D);
+            this.speedY[playerId] += speed * ((double) (this.rngSeed.next() % '\uc351') / 100000.0D - 0.25D);
+        }
         this.isLocalPlayer = isLocalPlayer;
         this.gameState = 2;
         this.aBoolean2843 = false;

--- a/client/src/main/java/org/moparforia/client/Game.java
+++ b/client/src/main/java/org/moparforia/client/Game.java
@@ -14,11 +14,11 @@ public class Game {
     private static final int WIDTH = 735;
     private static final int HEIGHT = 525;
 
-    public Game(JFrame frame, String server, int port, String lang, boolean verbose) {
+    public Game(JFrame frame, String server, int port, String lang, boolean verbose, boolean norandom) {
         Applet game = new AGolf();
 
 
-        game.setStub(new Stub(server, lang, port, verbose));
+        game.setStub(new Stub(server, lang, port, verbose, norandom));
         game.setSize(WIDTH, HEIGHT);
         game.init();
         game.start();
@@ -33,7 +33,7 @@ public class Game {
         private final Map<String, String> params;
         private String server;
 
-        public Stub(String server, String lang, int port, boolean verbose) {
+        public Stub(String server, String lang, int port, boolean verbose, boolean norandom) {
             if (server.indexOf(':') == -1) { // is ipv4
                 this.server = server;
             } else { // is ipv6
@@ -72,6 +72,7 @@ public class Game {
             params.put("localizationUrl", "");
             params.put("sharedLocalizationUrl", "");
             params.put("verbose", Boolean.toString(verbose));
+            params.put("norandom", Boolean.toString(norandom));
 
             //if(serverBox.isSelected())
             //params.put("tracktestmode", "true");

--- a/client/src/main/java/org/moparforia/client/Launcher.java
+++ b/client/src/main/java/org/moparforia/client/Launcher.java
@@ -41,6 +41,9 @@ public class Launcher implements Callable<Void> {
     @CommandLine.Option(names = {"--verbose", "-v"}, description = "Set if you want verbose information")
     private static boolean verbose = false;
 
+    @CommandLine.Option(names = {"--norandom", "-n"}, description = "Set if you want to disable randomization for shots")
+    private static boolean norandom = false;
+
     public static boolean debug() {
         return verbose;
     }
@@ -124,7 +127,7 @@ public class Launcher implements Callable<Void> {
             }
         }
 
-        launchGame(frame, hostname, port, lang, verbose);
+        launchGame(frame, hostname, port, lang, verbose, norandom);
         return null;
     }
 
@@ -136,8 +139,8 @@ public class Launcher implements Callable<Void> {
         return frame;
     }
 
-    public Game launchGame(JFrame frame, String hostname, int port, Language lang, boolean verbose) {
-        return new Game(frame, hostname, port, lang.toString(), verbose);
+    public Game launchGame(JFrame frame, String hostname, int port, Language lang, boolean verbose, boolean norandom) {
+        return new Game(frame, hostname, port, lang.toString(), verbose, norandom);
     }
 
     public Image loadIcon() throws IOException {

--- a/client/src/test/java/org/moparforia/client/LauncherCLITest.java
+++ b/client/src/test/java/org/moparforia/client/LauncherCLITest.java
@@ -84,6 +84,7 @@ class LauncherCLITest {
                 eq(Launcher.DEFAULT_SERVER),
                 eq(Launcher.DEFAULT_PORT),
                 eq(Launcher.Language.EN_US),
+                anyBoolean(),
                 anyBoolean());
 
         assertEquals(0, cmd.execute("--lang=Fi_fI"));
@@ -91,31 +92,33 @@ class LauncherCLITest {
                 eq(Launcher.DEFAULT_SERVER),
                 eq(Launcher.DEFAULT_PORT),
                 eq(Launcher.Language.FI_FI),
+                anyBoolean(),
                 anyBoolean());
     }
 
     @Test
     void testValidPortAndHostname() {
         assertEquals(0, cmd.execute("-p", "1111", "-ip", "128.128.128.128"));
-        verify(launcher).launchGame(any(), eq("128.128.128.128"), eq(1111), any(), anyBoolean());
+        verify(launcher).launchGame(any(), eq("128.128.128.128"), eq(1111), any(), anyBoolean(), anyBoolean());
 
         assertEquals(0, cmd.execute("-p=2222", "-ip=127.127.127.127"));
-        verify(launcher).launchGame(any(), eq("127.127.127.127"), eq(2222), any(), anyBoolean());
+        verify(launcher).launchGame(any(), eq("127.127.127.127"), eq(2222), any(), anyBoolean(), anyBoolean());
 
         assertEquals(0, cmd.execute("-p=3333", "-ip=126.126.126.126"));
-        verify(launcher).launchGame(any(), eq("126.126.126.126"), eq(3333), any(), anyBoolean());
+        verify(launcher).launchGame(any(), eq("126.126.126.126"), eq(3333), any(), anyBoolean(), anyBoolean());
     }
 
     @Test
     void testOnlyPort() {
         assertEquals(0, cmd.execute("-p", "1111"));
-        verify(launcher).launchGame(any(), eq(Launcher.DEFAULT_SERVER), eq(1111), any(), anyBoolean());
+        verify(launcher).launchGame(any(), eq(Launcher.DEFAULT_SERVER), eq(1111), any(), anyBoolean(), anyBoolean());
     }
 
     @Test
     void testOnlyHostname() {
         assertEquals(0, cmd.execute("-ip", "127.127.127.127"));
-        verify(launcher).launchGame(any(), eq("127.127.127.127"), eq(Launcher.DEFAULT_PORT), any(), anyBoolean());
+        verify(launcher).launchGame(any(), eq("127.127.127.127"), eq(Launcher.DEFAULT_PORT), any(), anyBoolean(),
+                anyBoolean());
     }
 
     @Test
@@ -126,6 +129,7 @@ class LauncherCLITest {
                 eq(Launcher.DEFAULT_SERVER),
                 eq(Launcher.DEFAULT_PORT),
                 eq(Launcher.Language.EN_US),
+                eq(false),
                 eq(false)
         );
     }


### PR DESCRIPTION
This change allows the client to pass -n (--norandom) to the launcher to disable any shot randomization.
In our group of players we consider this "pro mode" as luck is being removed from the equation.