### PR TITLE
Paint everything in the middle of the applet

### DIFF
--- a/client/src/main/java/agolf/GameApplet.java
+++ b/client/src/main/java/agolf/GameApplet.java
@@ -7,10 +7,7 @@ import com.aapeli.applet.AApplet;
 import com.aapeli.client.*;
 import org.moparforia.client.Launcher;
 
-import java.applet.Applet;
-import java.applet.AudioClip;
 import java.awt.*;
-import java.net.URL;
 
 public class GameApplet extends AApplet {
 
@@ -29,7 +26,7 @@ public class GameApplet extends AApplet {
     public static final Font fontDialog12 = new Font("Dialog", 0, 12);
     public static final Font fontDialog11 = new Font("Dialog", 0, 11);
     private GameContainer gameContainer;
-    private int anInt3769;
+    private int activePanel;
     private SynchronizedBool syncUnknownBool;
     private SynchronizedInteger syncPlayerAccessLevel;
     private boolean disableGuestChat;
@@ -112,7 +109,7 @@ public class GameApplet extends AApplet {
     }
 
     protected int method32() {
-        return this.anInt3769;
+        return this.activePanel;
     }
 
     public void setGameState(int state) {
@@ -123,15 +120,19 @@ public class GameApplet extends AApplet {
         this.setGameState(state, lobbyId, 0);
     }
 
-    protected void setGameState(int panelActive, int lobbyId, int lobbyExtra) {
-        if (panelActive != this.anInt3769 && this.syncIsValidSite.get()) {
-            this.anInt3769 = panelActive;
+    /**
+     * @param activePanel 0 == ?, 1 == login, 2 == lobby selection panel, 3 == in lobby, 4 == in game
+     * @param lobbyId game type, single player == 1, dual player == 2, multiplayer == 3
+     */
+    protected void setGameState(int activePanel, int lobbyId, int lobbyExtra) {
+        if (activePanel != this.activePanel && this.syncIsValidSite.get()) {
+            this.activePanel = activePanel;
             if (this.gameContainer.lobbySelectionPanel != null) {
                 this.gameContainer.lobbySelectionPanel.destroyRNOP();
             }
 
             this.clearContent();
-            if (panelActive == 1) {
+            if (activePanel == 1) {
                 if (this.aBoolean3773) {
                     super.param.removeSession();
                 } else {
@@ -151,16 +152,16 @@ public class GameApplet extends AApplet {
                 } else if (this.hasSession()) {
                     super.param.noGuestAutoLogin();
                     this.gameContainer.connection.writeData("login\t" + super.param.getSession());
-                    this.anInt3769 = 0;
+                    this.activePanel = 0;
                 } else if (!this.gameContainer.synchronizedTrackTestMode.get()) {
                     this.gameContainer.connection.writeData("login");
-                    this.anInt3769 = 0;
+                    this.activePanel = 0;
                 } else {
 
                 }
             }
 
-            if (panelActive == 2) {
+            if (activePanel == 2) {
                 if (this.gameContainer.lobbySelectionPanel == null) {
                     this.gameContainer.lobbySelectionPanel = new LobbySelectPanel(this.gameContainer, super.appletWidth, super.appletHeight);
                     this.gameContainer.lobbySelectionPanel.setLocation(0, 0);
@@ -187,7 +188,7 @@ public class GameApplet extends AApplet {
                 }
             }
 
-            if (panelActive == 3) {
+            if (activePanel == 3) {
                 this.gameContainer.gamePanel = null;
                 if (this.gameContainer.lobbyPanel == null) {
                     this.gameContainer.lobbyPanel = new LobbyPanel(this.gameContainer, super.appletWidth, super.appletHeight);
@@ -205,13 +206,13 @@ public class GameApplet extends AApplet {
                 this.addToContent(this.gameContainer.lobbyPanel);
             }
 
-            if (panelActive == 4) {
+            if (activePanel == 4) {
                 this.gameContainer.gamePanel = new GamePanel(this.gameContainer, super.appletWidth, super.appletHeight, this.anImage3774);
                 this.gameContainer.gamePanel.setLocation(0, 0);
                 this.addToContent(this.gameContainer.gamePanel);
             }
 
-            if (panelActive == 5) {
+            if (activePanel == 5) {
                 //super.param.showQuitPage();
                 System.exit(0);
             } else {

--- a/client/src/main/java/agolf/LobbySelectPanel.java
+++ b/client/src/main/java/agolf/LobbySelectPanel.java
@@ -8,7 +8,6 @@ import com.aapeli.tools.Tools;
 
 import java.awt.Color;
 import java.awt.Graphics;
-import java.awt.LayoutManager;
 import java.awt.Panel;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -34,6 +33,7 @@ public class LobbySelectPanel extends Panel implements ActionListener, MouseList
     private ColorButton buttonQuit;
     private ColorCheckbox checkboxPlayHidden;
     private Choicer choicerGraphics;
+    private Choicer audioChoicer;
     private int[] lobbyNumPlayers;
     private LobbySelectRNOPspammer lobbySelectRNOP;
     private static final String[] aStringArray544 = new String[22];
@@ -139,7 +139,12 @@ public class LobbySelectPanel extends Panel implements ActionListener, MouseList
     }
 
     public void itemStateChanged(ItemEvent evt) {
-        this.gameContainer.graphicsQualityIndex = this.choicerGraphics.getSelectedIndex();
+        Object source = evt.getSource();
+        if (source == this.choicerGraphics) {
+            this.gameContainer.graphicsQualityIndex = this.choicerGraphics.getSelectedIndex();
+        } else if (source == this.audioChoicer) {
+            this.gameContainer.soundManager.audioChoicerIndex = this.audioChoicer.getSelectedIndex();
+        }
     }
 
     public static String getLobbySelectMessage(int lobbyId) {
@@ -209,7 +214,7 @@ public class LobbySelectPanel extends Panel implements ActionListener, MouseList
     }
 
     private void create() {
-        this.setLayout((LayoutManager) null);
+        this.setLayout(null);
         this.checkboxPlayHidden = new ColorCheckbox(this.gameContainer.textManager.getGame("LobbySelect_PlayHidden"));
         this.checkboxPlayHidden.setBounds(this.width / 6 - 75 - 10, this.height - 124, 220, 18);
         this.checkboxPlayHidden.setBackground(GameApplet.colourGameBackground);
@@ -226,34 +231,43 @@ public class LobbySelectPanel extends Panel implements ActionListener, MouseList
             this.add(this.buttonSingleQuick);
         }
 
-
-
         //this.buttonDual = new ColorButton(this.gameContainer.textManager.getGame("LobbySelect_DualPlayer"));
         this.buttonDual = new ColorButton("Coming soon...");
         this.buttonDual.setBounds(this.width * 3 / 6 - 75, this.height - 150, 150, 25);
         //this.buttonDual.addActionListener(this);
         this.add(this.buttonDual);
 
-
         this.buttonMulti = new ColorButton(this.gameContainer.textManager.getGame("LobbySelect_MultiPlayer"));
         this.buttonMulti.setBounds(this.width * 5 / 6 - 75, this.height - 150, 150, 25);
         this.buttonMulti.addActionListener(this);
         this.add(this.buttonMulti);
+
         this.buttonMultiQuick = new ColorButton(this.gameContainer.textManager.getGame("LobbySelect_QuickStart"));
         this.buttonMultiQuick.setBackground(GameApplet.colourButtonBlue);
         this.buttonMultiQuick.setBounds(this.width * 5 / 6 - 50, this.height - 95, 100, 20);
         this.buttonMultiQuick.addActionListener(this);
         this.add(this.buttonMultiQuick);
-        String text = this.gameContainer.textManager.getGame("LobbySelect_Gfx");
+
+        String graphicsOptionText = this.gameContainer.textManager.getGame("LobbySelect_Gfx");
         this.choicerGraphics = new Choicer();
-        this.choicerGraphics.addItem(text + " " + this.gameContainer.textManager.getGame("LobbySelect_Gfx0"));
-        this.choicerGraphics.addItem(text + " " + this.gameContainer.textManager.getGame("LobbySelect_Gfx1"));
-        this.choicerGraphics.addItem(text + " " + this.gameContainer.textManager.getGame("LobbySelect_Gfx2"));
-        this.choicerGraphics.addItem(text + " " + this.gameContainer.textManager.getGame("LobbySelect_Gfx3"));
+        this.choicerGraphics.addItem(graphicsOptionText + " " + this.gameContainer.textManager.getGame("LobbySelect_Gfx0"));
+        this.choicerGraphics.addItem(graphicsOptionText + " " + this.gameContainer.textManager.getGame("LobbySelect_Gfx1"));
+        this.choicerGraphics.addItem(graphicsOptionText + " " + this.gameContainer.textManager.getGame("LobbySelect_Gfx2"));
+        this.choicerGraphics.addItem(graphicsOptionText + " " + this.gameContainer.textManager.getGame("LobbySelect_Gfx3"));
         this.choicerGraphics.select(this.gameContainer.graphicsQualityIndex);
-        this.choicerGraphics.setBounds(this.width / 3 - 100, this.height - 10 - 20, 200, 20);
+        this.choicerGraphics.setBounds(this.width / 3 - 100, this.height - 10 - 50, 200, 20);
         this.choicerGraphics.addItemListener(this);
         this.add(this.choicerGraphics);
+
+        String audioOptionsText = "Audio:";
+        this.audioChoicer = new Choicer();
+        this.audioChoicer.addItem(audioOptionsText + " On");
+        this.audioChoicer.addItem(audioOptionsText + " Off");
+        this.audioChoicer.select(this.gameContainer.soundManager.audioChoicerIndex);
+        this.audioChoicer.setBounds(this.width / 3 - 100, this.height - 10 - 20, 200, 20);
+        this.audioChoicer.addItemListener(this);
+        this.add(this.audioChoicer);
+
         this.buttonQuit = new ColorButton(this.gameContainer.textManager.getGame("LobbySelect_Quit"));
         this.buttonQuit.setBackground(GameApplet.colourButtonRed);
         this.buttonQuit.setBounds(this.width * 2 / 3 - 50, this.height - 10 - 20, 100, 20);

--- a/client/src/main/java/com/aapeli/applet/AApplet.java
+++ b/client/src/main/java/com/aapeli/applet/AApplet.java
@@ -16,6 +16,7 @@ import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Graphics;
+import java.awt.GridBagLayout;
 import java.awt.Image;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -282,16 +283,18 @@ public abstract class AApplet extends Applet implements Runnable, ActionListener
                 }
             }
 
-            graphics.drawImage(this.appletImage, 0, 0, this);
+            int x = (this.getWidth() - appletImage.getWidth(null)) / 2;
+            int y = (this.getHeight() - appletImage.getHeight(null)) / 2;
+            graphics.drawImage(this.appletImage, x, y, this);
         }
     }
 
     public void run() {
         long startTime = System.currentTimeMillis();
-        this.setLayout(null);
+        this.setLayout(new GridBagLayout());
         this.loadingPanel = new LoadingPanel(this);
-        this.loadingPanel.setBounds(0, 0, this.appletWidth, this.appletHeight);
         this.add(this.loadingPanel);
+        this.revalidate();
         this.loadingPanel.start();
         this.param = new Parameters(this, this.isDebug());
         String initMessage = this.param.getParameter("initmessage");
@@ -495,7 +498,6 @@ public abstract class AApplet extends Applet implements Runnable, ActionListener
                                             }
 
                                             this.contentPanel = new ContentPanel(this);
-                                            this.contentPanel.setBounds(0, 0, this.appletWidth, this.appletHeight);
                                             if (this.backgroundImageKey != null) {
                                                 this.contentPanel.setBackground(this.imageManager, this.backgroundImageKey, this.backgroundXOffset, this.backgroundYOffset);
                                             }
@@ -573,13 +575,15 @@ public abstract class AApplet extends Applet implements Runnable, ActionListener
                 this.contentPanel.destroy();
             }
 
+            int x = (this.getWidth() - this.appletWidth) / 2;
+            int y = (this.getHeight() - this.appletHeight) / 2;
             if (state == END_ERROR_CONNECTION) {
                 this.retryCanvas = new RetryCanvas(this.textManager.getShared("Message_CE_RetryButton"), 120, 20, this);
-                this.retryCanvas.setLocation(40, 360);
+                this.retryCanvas.setLocation(x + 40, y + 360);
                 this.add(this.retryCanvas);
             } else if (state == END_THROWABLE) {
                 this.retryCanvas = new RetryCanvas(this.textManager.getShared("Message_PE_RetryButton"), 120, 20, this);
-                this.retryCanvas.setLocation(50, 360);
+                this.retryCanvas.setLocation(x + 50, y + 360);
                 this.add(this.retryCanvas);
             }
 
@@ -616,6 +620,7 @@ public abstract class AApplet extends Applet implements Runnable, ActionListener
     public void contentReady() {
         if (this.endState == 0) {
             this.contentPanel.makeVisible();
+            this.revalidate();
         }
 
     }

--- a/client/src/main/java/com/aapeli/applet/AApplet.java
+++ b/client/src/main/java/com/aapeli/applet/AApplet.java
@@ -59,10 +59,10 @@ public abstract class AApplet extends Applet implements Runnable, ActionListener
     private int endState;
     private String endTextCustom;
     private Throwable aThrowable2553;
-    private boolean aBoolean2554;
+    private boolean drawTextOutline;
     private boolean notStarted;
     private boolean destroyed;
-    private boolean aBoolean2557;
+    private boolean ready;
     private RetryCanvas retryCanvas;
     private Image splashImage;
     private long splashTimestamp;
@@ -83,8 +83,8 @@ public abstract class AApplet extends Applet implements Runnable, ActionListener
         this.endState = 0;
         this.endTextCustom = null;
         this.aThrowable2553 = null;
-        this.aBoolean2554 = false;
-        this.aBoolean2557 = false;
+        this.drawTextOutline = false;
+        this.ready = false;
         this.notStarted = true;
         this.destroyed = false;
         this.verbose = false;
@@ -181,47 +181,47 @@ public abstract class AApplet extends Applet implements Runnable, ActionListener
 
                 if (this.textManager != null) {
                     this.appletGraphics.setColor(this.getForeground());
-                    Color color = this.aBoolean2554 ? backgroundColor : null;
+                    Color outlineColor = this.drawTextOutline ? backgroundColor : null;
                     if (this.endState == END_ERROR_CONNECTION) {
-                        byte yOffset = -20;
+                        byte textYOffset = -20;
                         this.appletGraphics.setFont(fontDialog15);
-                        StringDraw.drawOutlinedString(this.appletGraphics, color, this.textManager.getShared("Message_CE_ConnectionError"), 40, 80 + yOffset, -1);
+                        StringDraw.drawOutlinedString(this.appletGraphics, outlineColor, this.textManager.getShared("Message_CE_ConnectionError"), 40,80 + textYOffset, -1);
                         this.appletGraphics.setFont(fontDialog12);
-                        StringDraw.drawOutlinedString(this.appletGraphics, color, this.textManager.getShared("Message_CE_PossibleReasons"), 40, 125 + yOffset, -1);
-                        if (!this.aBoolean2557) {
+                        StringDraw.drawOutlinedString(this.appletGraphics, outlineColor, this.textManager.getShared("Message_CE_PossibleReasons"), 40,125 + textYOffset, -1);
+                        if (!this.ready) {
                             this.appletGraphics.setFont(fontDialog12);
-                            StringDraw.drawOutlinedString(this.appletGraphics, color, "- " + this.textManager.getShared("Message_CE0_1_Short"), 40, 160 + yOffset, -1);
+                            StringDraw.drawOutlinedString(this.appletGraphics, outlineColor, "- " + this.textManager.getShared("Message_CE0_1_Short"), 40,160 + textYOffset, -1);
                             this.appletGraphics.setFont(fontDialog11);
-                            StringDraw.drawOutlinedStringWithMaxWidth(this.appletGraphics, color, this.textManager.getShared("Message_CE0_1_Long", this.param.getServerIp(), "" + this.param.getServerPort()), 50, 180 + yOffset, -1, this.appletWidth - 50 - 50);
+                            StringDraw.drawOutlinedStringWithMaxWidth(this.appletGraphics, outlineColor, this.textManager.getShared("Message_CE0_1_Long", this.param.getServerIp(), "" + this.param.getServerPort()), 50, 180 + textYOffset, -1, this.appletWidth - 50 - 50);
                             this.appletGraphics.setFont(fontDialog12);
-                            StringDraw.drawOutlinedString(this.appletGraphics, color, "- " + this.textManager.getShared("Message_CE0_2_Short"), 40, 245 + yOffset, -1);
+                            StringDraw.drawOutlinedString(this.appletGraphics, outlineColor, "- " + this.textManager.getShared("Message_CE0_2_Short"), 40,245 + textYOffset, -1);
                             this.appletGraphics.setFont(fontDialog11);
-                            StringDraw.drawOutlinedStringWithMaxWidth(this.appletGraphics, color, this.textManager.getShared("Message_CE0_2_Long"), 50, 265 + yOffset, -1, this.appletWidth - 50 - 50);
+                            StringDraw.drawOutlinedStringWithMaxWidth(this.appletGraphics, outlineColor, this.textManager.getShared("Message_CE0_2_Long"), 50,265 + textYOffset, -1, this.appletWidth - 50 - 50);
                             this.appletGraphics.setFont(fontDialog12);
-                            StringDraw.drawOutlinedString(this.appletGraphics, color, "- " + this.textManager.getShared("Message_CE0_3_Short"), 40, 305 + yOffset, -1);
+                            StringDraw.drawOutlinedString(this.appletGraphics, outlineColor, "- " + this.textManager.getShared("Message_CE0_3_Short"), 40,305 + textYOffset, -1);
                             this.appletGraphics.setFont(fontDialog11);
-                            StringDraw.drawOutlinedStringWithMaxWidth(this.appletGraphics, color, this.textManager.getShared("Message_CE0_3_Long"), 50, 325 + yOffset, -1, this.appletWidth - 50 - 50);
+                            StringDraw.drawOutlinedStringWithMaxWidth(this.appletGraphics, outlineColor, this.textManager.getShared("Message_CE0_3_Long"), 50,325 + textYOffset, -1, this.appletWidth - 50 - 50);
                         } else {
                             this.appletGraphics.setFont(fontDialog12);
-                            StringDraw.drawOutlinedString(this.appletGraphics, color, "- " + this.textManager.getShared("Message_CE1_1_Short"), 40, 160 + yOffset, -1);
+                            StringDraw.drawOutlinedString(this.appletGraphics, outlineColor, "- " + this.textManager.getShared("Message_CE1_1_Short"), 40,160 + textYOffset, -1);
                             this.appletGraphics.setFont(fontDialog11);
-                            StringDraw.drawOutlinedStringWithMaxWidth(this.appletGraphics, color, this.textManager.getShared("Message_CE1_1_Long"), 50, 180 + yOffset, -1, this.appletWidth - 50 - 50);
+                            StringDraw.drawOutlinedStringWithMaxWidth(this.appletGraphics, outlineColor, this.textManager.getShared("Message_CE1_1_Long"), 50,180 + textYOffset, -1, this.appletWidth - 50 - 50);
                             this.appletGraphics.setFont(fontDialog12);
-                            StringDraw.drawOutlinedString(this.appletGraphics, color, "- " + this.textManager.getShared("Message_CE1_2_Short"), 40, 235 + yOffset, -1);
+                            StringDraw.drawOutlinedString(this.appletGraphics, outlineColor, "- " + this.textManager.getShared("Message_CE1_2_Short"), 40,235 + textYOffset, -1);
                             this.appletGraphics.setFont(fontDialog11);
-                            StringDraw.drawOutlinedStringWithMaxWidth(this.appletGraphics, color, this.textManager.getShared("Message_CE1_2_Long"), 50, 255 + yOffset, -1, this.appletWidth - 50 - 50);
+                            StringDraw.drawOutlinedStringWithMaxWidth(this.appletGraphics, outlineColor, this.textManager.getShared("Message_CE1_2_Long"), 50,255 + textYOffset, -1, this.appletWidth - 50 - 50);
                             this.appletGraphics.setFont(fontDialog12);
-                            StringDraw.drawOutlinedString(this.appletGraphics, color, "- " + this.textManager.getShared("Message_CE1_3_Short"), 40, 305 + yOffset, -1);
+                            StringDraw.drawOutlinedString(this.appletGraphics, outlineColor, "- " + this.textManager.getShared("Message_CE1_3_Short"), 40,305 + textYOffset, -1);
                             this.appletGraphics.setFont(fontDialog11);
-                            StringDraw.drawOutlinedStringWithMaxWidth(this.appletGraphics, color, this.textManager.getShared("Message_CE1_3_Long"), 50, 325 + yOffset, -1, this.appletWidth - 50 - 50);
+                            StringDraw.drawOutlinedStringWithMaxWidth(this.appletGraphics, outlineColor, this.textManager.getShared("Message_CE1_3_Long"), 50,325 + textYOffset, -1, this.appletWidth - 50 - 50);
                         }
                     } else if (this.endState == END_THROWABLE) {
                         this.appletGraphics.setFont(fontDialog15);
-                        StringDraw.drawOutlinedString(this.appletGraphics, color, this.textManager.getShared("Message_PE_ProgramError"), 50, 100, -1);
+                        StringDraw.drawOutlinedString(this.appletGraphics, outlineColor, this.textManager.getShared("Message_PE_ProgramError"), 50,100, -1);
                         this.appletGraphics.setFont(fontDialog12);
-                        StringDraw.drawOutlinedStringWithMaxWidth(this.appletGraphics, color, this.textManager.getShared("Message_PE_GameClosed"), 50, 150, -1, this.appletWidth - 70 - 50);
+                        StringDraw.drawOutlinedStringWithMaxWidth(this.appletGraphics, outlineColor, this.textManager.getShared("Message_PE_GameClosed"), 50,150, -1, this.appletWidth - 70 - 50);
                         this.appletGraphics.setFont(fontDialog12b);
-                        StringDraw.drawOutlinedString(this.appletGraphics, color, this.textManager.getShared("Message_PE_ErrorDesc", this.aThrowable2553.toString()), 50, 235, -1);
+                        StringDraw.drawOutlinedString(this.appletGraphics, outlineColor, this.textManager.getShared("Message_PE_ErrorDesc", this.aThrowable2553.toString()), 50, 235, -1);
                     } else {
                         String endText = this.textManager.getShared("Message_WaitWhile");
                         String endTextHelp = null;
@@ -261,21 +261,21 @@ public abstract class AApplet extends Applet implements Runnable, ActionListener
 
                         this.appletGraphics.setFont(fontDialog15);
                         if (this.endTextLocation == TEXT_CENTER) {
-                            StringDraw.drawOutlinedString(this.appletGraphics, color, endText, this.appletWidth / 2, this.appletHeight / 2 - 10, 0);
+                            StringDraw.drawOutlinedString(this.appletGraphics, outlineColor, endText, this.appletWidth / 2, this.appletHeight / 2 - 10, 0);
                         } else if (this.endTextLocation == TEXT_LOWERLEFT) {
-                            StringDraw.drawOutlinedString(this.appletGraphics, color, endText, this.appletWidth / 12, this.appletHeight - 120, -1);
+                            StringDraw.drawOutlinedString(this.appletGraphics, outlineColor, endText, this.appletWidth / 12, this.appletHeight - 120, -1);
                         } else if (this.endTextLocation == TEXT_LOWERMIDDLE) {
-                            StringDraw.drawOutlinedString(this.appletGraphics, color, endText, this.appletWidth / 2, this.appletHeight - 120, 0);
+                            StringDraw.drawOutlinedString(this.appletGraphics, outlineColor, endText, this.appletWidth / 2, this.appletHeight - 120, 0);
                         }
 
                         if (endTextHelp != null) {
                             this.appletGraphics.setFont(fontDialog12);
                             if (this.endTextLocation == TEXT_CENTER) {
-                                StringDraw.drawOutlinedStringWithMaxWidth(this.appletGraphics, color, endTextHelp, this.appletWidth / 2, this.appletHeight / 2 + 30, 0, (int) ((double) this.appletWidth * 0.8D));
+                                StringDraw.drawOutlinedStringWithMaxWidth(this.appletGraphics, outlineColor, endTextHelp, this.appletWidth / 2, this.appletHeight / 2 + 30, 0, (int) ((double) this.appletWidth * 0.8D));
                             } else if (this.endTextLocation == TEXT_LOWERLEFT) {
-                                StringDraw.drawOutlinedStringWithMaxWidth(this.appletGraphics, color, endTextHelp, this.appletWidth / 12, this.appletHeight - 80, -1, (int) ((double) this.appletWidth * 0.6D));
+                                StringDraw.drawOutlinedStringWithMaxWidth(this.appletGraphics, outlineColor, endTextHelp, this.appletWidth / 12, this.appletHeight - 80, -1, (int) ((double) this.appletWidth * 0.6D));
                             } else if (this.endTextLocation == TEXT_LOWERMIDDLE) {
-                                StringDraw.drawOutlinedStringWithMaxWidth(this.appletGraphics, color, endTextHelp, this.appletWidth / 2, this.appletHeight - 80, 0, (int) ((double) this.appletWidth * 0.5D));
+                                StringDraw.drawOutlinedStringWithMaxWidth(this.appletGraphics, outlineColor, endTextHelp, this.appletWidth / 2, this.appletHeight - 80, 0, (int) ((double) this.appletWidth * 0.5D));
                             }
                         }
                     }
@@ -344,7 +344,7 @@ public abstract class AApplet extends Applet implements Runnable, ActionListener
 
             this.loadingPanel.setActualProgress(0.5D);
             this.textManager = new TextManager(this.param, true, this.isDebug());
-            this.loadingPanel.method462(this.param, this.textManager);
+            this.loadingPanel.init(this.param, this.textManager);
             if (startupDebug) {
                 this.printSUD("Loading texts...");
             }
@@ -458,7 +458,7 @@ public abstract class AApplet extends Applet implements Runnable, ActionListener
 
                                 if (this.endState == 0) {
                                     int readyTime = (int) (System.currentTimeMillis() - startTime);
-                                    this.aBoolean2557 = true;
+                                    this.ready = true;
                                     if (startupDebug) {
                                         this.printSUD("Waiting loader screen to finish...");
                                     }
@@ -555,13 +555,13 @@ public abstract class AApplet extends Applet implements Runnable, ActionListener
         this.repaint();
     }
 
-    public void setTextLocation(int var1) {
-        this.endTextLocation = var1;
+    public void setTextLocation(int textLocation) {
+        this.endTextLocation = textLocation;
         this.repaint();
     }
 
-    public void setTextOutline(boolean var1) {
-        this.aBoolean2554 = var1;
+    public void setTextOutline(boolean drawTextOutline) {
+        this.drawTextOutline = drawTextOutline;
         this.repaint();
     }
 
@@ -606,9 +606,9 @@ public abstract class AApplet extends Applet implements Runnable, ActionListener
 
     }
 
-    public void addToContent(Component var1) {
+    public void addToContent(Component component) {
         if (this.endState == 0) {
-            this.contentPanel.add(var1);
+            this.contentPanel.add(component);
         }
 
     }

--- a/client/src/main/java/com/aapeli/applet/AdCanvas.java
+++ b/client/src/main/java/com/aapeli/applet/AdCanvas.java
@@ -47,7 +47,7 @@ class AdCanvas extends Canvas implements MouseListener {
         if (this.aBoolean123) {
             if (!this.aBoolean125) {
                 if (this.loadingPanel != null) {
-                    Image var2 = this.loadingPanel.method469();
+                    Image var2 = this.loadingPanel.getImage();
                     if (var2 != null) {
                         Point var3 = this.getLocation();
                         var1.drawImage(var2, -var3.x, -var3.y, this);

--- a/client/src/main/java/com/aapeli/applet/ContentPanel.java
+++ b/client/src/main/java/com/aapeli/applet/ContentPanel.java
@@ -2,12 +2,16 @@ package com.aapeli.applet;
 
 import com.aapeli.client.IPanel;
 
+import java.awt.Dimension;
+
 
 class ContentPanel extends IPanel {
 
     protected ContentPanel(AApplet applet) {
         this.setBackground(applet.getBackground());
         this.setForeground(applet.getForeground());
+        this.setSize(applet.appletWidth, applet.appletHeight);
+        this.setPreferredSize(new Dimension(applet.appletWidth, applet.appletHeight));
         this.setLayout(null);
     }
 

--- a/client/src/main/java/com/aapeli/applet/LoadingPanel.java
+++ b/client/src/main/java/com/aapeli/applet/LoadingPanel.java
@@ -50,6 +50,8 @@ class LoadingPanel extends Panel implements Runnable, ActionListener {
         this.destroyed = false;
         this.needsRepaint = true;
         this.aBoolean589 = true;
+        this.setSize(applet.appletWidth, applet.appletHeight);
+        this.setPreferredSize(new Dimension(applet.appletWidth, applet.appletHeight));
         this.startGameClicked = -1;
     }
 

--- a/client/src/main/java/com/aapeli/applet/LoadingPanel.java
+++ b/client/src/main/java/com/aapeli/applet/LoadingPanel.java
@@ -26,7 +26,7 @@ class LoadingPanel extends Panel implements Runnable, ActionListener {
     private double renderedProgress;
     private double aDouble586;
     private int updateInterval;
-    private boolean aBoolean588;
+    private boolean needsRepaint;
     private boolean aBoolean589;
     private boolean loaded;
     private boolean destroyed;
@@ -48,7 +48,7 @@ class LoadingPanel extends Panel implements Runnable, ActionListener {
         this.updateInterval = 50;
         this.loaded = false;
         this.destroyed = false;
-        this.aBoolean588 = true;
+        this.needsRepaint = true;
         this.aBoolean589 = true;
         this.startGameClicked = -1;
     }
@@ -66,7 +66,7 @@ class LoadingPanel extends Panel implements Runnable, ActionListener {
                 if (this.panelImage == null) {
                     this.panelImage = this.createImage(width, height);
                     this.panelGraphics = this.panelImage.getGraphics();
-                    this.aBoolean588 = true;
+                    this.needsRepaint = true;
                 }
 
                 Color background = this.getBackground();
@@ -74,9 +74,9 @@ class LoadingPanel extends Panel implements Runnable, ActionListener {
                     background = new Color(24, 24, 24);
                 }
 
-                boolean var6 = this.aBoolean588;
-                this.aBoolean588 = false;
-                if (var6) {
+                boolean needsRepaint = this.needsRepaint;
+                this.needsRepaint = false;
+                if (needsRepaint) {
                     this.drawGradient(this.panelGraphics, background, 0, 32, 0, height, 0, width, this.aBoolean589);
                     this.aBoolean589 = false;
                     if (this.loadingMessage != null && this.startGameClicked == -1) {
@@ -107,7 +107,7 @@ class LoadingPanel extends Panel implements Runnable, ActionListener {
 
     public void setBackground(Color var1) {
         super.setBackground(var1);
-        this.aBoolean588 = true;
+        this.needsRepaint = true;
         this.repaint();
     }
 
@@ -156,7 +156,7 @@ class LoadingPanel extends Panel implements Runnable, ActionListener {
 
     }
 
-    protected void method462(Parameters parameters, TextManager textManager) {
+    protected void init(Parameters parameters, TextManager textManager) {
         this.parameters = parameters;
         this.textManager = textManager;
     }
@@ -168,7 +168,7 @@ class LoadingPanel extends Panel implements Runnable, ActionListener {
 
     protected void setLoadingMessage(String message) {
         this.loadingMessage = message;
-        this.aBoolean588 = true;
+        this.needsRepaint = true;
         this.repaint();
     }
 
@@ -196,7 +196,7 @@ class LoadingPanel extends Panel implements Runnable, ActionListener {
         this.aDouble586 *= var1;
     }
 
-    protected Image method469() {
+    protected Image getImage() {
         return this.panelImage;
     }
 
@@ -212,7 +212,7 @@ class LoadingPanel extends Panel implements Runnable, ActionListener {
         if (this.adCanvas != null) {
             if (this.aBoolean595) {
                 this.startGameClicked = 0;
-                this.aBoolean588 = true;
+                this.needsRepaint = true;
                 this.repaint();
                 short var1 = 300;
                 int var2 = (this.gameApplet.appletWidth - 25 - 15 - 15 - 25) / 2;

--- a/client/src/main/java/com/aapeli/client/SoundManager.java
+++ b/client/src/main/java/com/aapeli/client/SoundManager.java
@@ -18,6 +18,7 @@ public final class SoundManager implements Runnable {
     private Hashtable<Integer, SoundClip> clientSounds;
     private Hashtable<String, SoundClip> sharedSounds;
     private boolean clipLoaderThreadRunning;
+    public int audioChoicerIndex;
 
 
     public SoundManager(AApplet applet) {
@@ -33,6 +34,7 @@ public final class SoundManager implements Runnable {
         this.applet = applet;
         this.loadSoundClipsOnRegister = loadClipsOnRegister;
         this.debug = debug;
+        this.audioChoicerIndex = 0;
         this.loadClientSounds();
         this.sharedSoundDir = this.getClass().getResource("/sound/shared/");
 
@@ -231,7 +233,7 @@ public final class SoundManager implements Runnable {
 
     private void playAudioClip(int id) {
         SoundClip soundClip = this.clientSounds.get(new Integer(id));
-        if (soundClip != null) {
+        if (soundClip != null && this.audioChoicerIndex != 1) {
             AudioClip audioClip = soundClip.getAudioClip();
             if (audioClip != null) {
                 audioClip.play();

--- a/client/src/main/java/com/aapeli/client/StringDraw.java
+++ b/client/src/main/java/com/aapeli/client/StringDraw.java
@@ -17,11 +17,11 @@ public class StringDraw {
     public static final int ALIGN_CENTER_RIGHT_ALWAYS_VISIBLE = 2;
 
 
-    public static int drawString(Graphics g, String colour, int x, int y, int alignment) {
-        return drawOutlinedString(g, (Color) null, colour, x, y, alignment);
+    public static int drawString(Graphics g, String text, int x, int y, int alignment) {
+        return drawOutlinedString(g, null, text, x, y, alignment);
     }
 
-    public static int drawOutlinedString(Graphics g, Color colour, String text, int x, int y, int alignment) {
+    public static int drawOutlinedString(Graphics g, Color outlineColor, String text, int x, int y, int alignment) {
         int textWidth = getStringWidth(g, text);
         if (alignment == ALIGN_CENTER || alignment == ALIGN_CENTER_LEFT_ALWAYS_VISIBLE || alignment == ALIGN_CENTER_RIGHT_ALWAYS_VISIBLE) {
             x -= textWidth / 2;
@@ -35,22 +35,22 @@ public class StringDraw {
             Rectangle bounds = g.getClipBounds();
             if (bounds != null) {
                 if (alignment == ALIGN_CENTER_LEFT_ALWAYS_VISIBLE) {
-                    if (colour == null && x < 0) {
+                    if (outlineColor == null && x < 0) {
                         x = 0;
-                    } else if (colour != null && x < 1) {
+                    } else if (outlineColor != null && x < 1) {
                         x = 1;
                     }
-                } else if (colour == null && x + textWidth >= bounds.width) {
+                } else if (outlineColor == null && x + textWidth >= bounds.width) {
                     x = bounds.width - 1 - textWidth;
-                } else if (colour != null && x + textWidth >= bounds.width - 1) {
+                } else if (outlineColor != null && x + textWidth >= bounds.width - 1) {
                     x = bounds.width - 2 - textWidth;
                 }
             }
         }
 
-        if (colour != null) {
+        if (outlineColor != null) {
             Color oldColour = g.getColor();
-            g.setColor(colour);
+            g.setColor(outlineColor);
             g.drawString(text, x - 1, y);
             g.drawString(text, x + 1, y);
             g.drawString(text, x, y - 1);
@@ -63,113 +63,113 @@ public class StringDraw {
     }
 
     public static int[] drawStringWithMaxWidth(Graphics g, String text, int var2, int var3, int var4, int var5) {
-        return drawOutlinedStringWithMaxWidth(g, (Color) null, text, var2, var3, var4, var5);
+        return drawOutlinedStringWithMaxWidth(g, null, text, var2, var3, var4, var5);
     }
 
-    public static int[] drawOutlinedStringWithMaxWidth(Graphics g, Color colour, String text, int x, int y, int alignment, int var6) {
+    public static int[] drawOutlinedStringWithMaxWidth(Graphics g, Color outlineColor, String text, int x, int y, int alignment, int maxWidth) {
         Font font = g.getFont();
         FontMetrics fontMetrics = g.getFontMetrics(font);
-        Vector vector = createLines(fontMetrics, text, var6);
+        Vector<String> lines = createLines(fontMetrics, text, maxWidth);
         int fontSize = font.getSize();
-        int var11 = fontSize + (fontSize + 4) / 5;
-        if (colour != null) {
-            var11 += 2;
+        int lineHeight = fontSize + (fontSize + 4) / 5;
+        if (outlineColor != null) {
+            lineHeight += 2;
         }
 
-        int[] var12 = new int[]{vector.size(), 0, 0};
-        var12[1] = var12[0] * var11;
-        var12[2] = 0;
+        int[] linesData = new int[]{lines.size(), 0, 0}; // 0 == number of lines, 1 == height, 2 == width
+        linesData[1] = linesData[0] * lineHeight;
+        linesData[2] = 0;
 
-        for (int var14 = 0; var14 < var12[0]; ++var14) {
-            int var13 = drawOutlinedString(g, colour, (String) vector.elementAt(var14), x, y, alignment);
-            if (var13 > var12[2]) {
-                var12[2] = var13;
+        for (int line = 0; line < linesData[0]; ++line) {
+            int lineWidth = drawOutlinedString(g, outlineColor, lines.elementAt(line), x, y, alignment);
+            if (lineWidth > linesData[2]) {
+                linesData[2] = lineWidth;
             }
 
-            y += var11;
+            y += lineHeight;
         }
 
-        return var12;
+        return linesData;
     }
 
-    public static int drawString(Graphics var0, String var1, int var2, int var3, int var4, int var5) {
-        int[] var6 = drawOutlinedStringWithMaxWidth(var0, null, var1, var2, var3, var4, var5);
-        return var6[2];
+    public static int drawString(Graphics g, String text, int x, int y, int alignment, int maxWidth) {
+        int[] linesData = drawOutlinedStringWithMaxWidth(g, null, text, x, y, alignment, maxWidth);
+        return linesData[2];
     }
 
-    public static int getStringWidth(Graphics var0, String var1) {
-        return getStringWidth(var0, var0.getFont(), var1);
+    public static int getStringWidth(Graphics g, String text) {
+        return getStringWidth(g, g.getFont(), text);
     }
 
-    public static int getStringWidth(Graphics var0, Font var1, String var2) {
-        return getStringWidth(var0.getFontMetrics(var1), var2);
+    public static int getStringWidth(Graphics g, Font font, String text) {
+        return getStringWidth(g.getFontMetrics(font), text);
     }
 
-    public static int getStringWidth(Component var0, Font var1, String var2) {
-        return getStringWidth(var0.getFontMetrics(var1), var2);
+    public static int getStringWidth(Component component, Font font, String text) {
+        return getStringWidth(component.getFontMetrics(font), text);
     }
 
-    public static int getStringWidth(FontMetrics var0, String var1) {
-        return var0.stringWidth(var1);
+    public static int getStringWidth(FontMetrics fontMetrics, String text) {
+        return fontMetrics.stringWidth(text);
     }
 
-    public static Vector createLines(Graphics var0, String var1, int var2) {
-        return createLines(var0, var0.getFont(), var1, var2);
+    public static Vector<String> createLines(Graphics g, String text, int maximumWidth) {
+        return createLines(g, g.getFont(), text, maximumWidth);
     }
 
-    public static Vector createLines(Graphics var0, Font var1, String var2, int var3) {
-        return createLines(var0.getFontMetrics(var1), var2, var3);
+    public static Vector<String> createLines(Graphics g, Font font, String text, int maximumWidth) {
+        return createLines(g.getFontMetrics(font), text, maximumWidth);
     }
 
-    public static Vector createLines(Component var0, Font var1, String var2, int var3) {
-        return createLines(var0.getFontMetrics(var1), var2, var3);
+    public static Vector<String> createLines(Component component, Font font, String text, int maximumWidth) {
+        return createLines(component.getFontMetrics(font), text, maximumWidth);
     }
 
-    public static Vector createLines(FontMetrics var0, String var1, int var2) {
-        Vector var3 = new Vector();
-        method1697(var3, var1, var0, var2);
-        return var3;
+    public static Vector<String> createLines(FontMetrics fontMetrics, String text, int maximumWidth) {
+        Vector<String> lines = new Vector<>();
+        createLinesPrivate(lines, text, fontMetrics, maximumWidth);
+        return lines;
     }
 
-    private static void method1697(Vector var0, String var1, FontMetrics var2, int var3) {
-        String var4 = var1;
-        int var6 = var1.indexOf(10);
-        if (var6 >= 0) {
-            var4 = var1.substring(0, var6);
+    private static void createLinesPrivate(Vector<String> lines, String text, FontMetrics fontMetrics, int maximumWidth) {
+        String line = text;
+        int linebreak = text.indexOf('\n');
+        if (linebreak >= 0) {
+            line = text.substring(0, linebreak);
         }
 
-        boolean var7 = false;
+        boolean lineIsEmpty = false;
 
-        while (!var7 && getStringWidth(var2, var4) > var3) {
-            String var5 = var4;
-            var4 = method1698(var4);
-            if (var4.length() == 0) {
-                var4 = var5;
-                var7 = true;
-            }
-        }
-
-        var0.addElement(var4);
-        int var8 = var4.length();
-        if (var8 < var1.length()) {
-            String var9 = var1.substring(var8);
-            if (Character.isWhitespace(var9.charAt(0))) {
-                var9 = var9.substring(1);
-            }
-
-            if (var9.length() > 0) {
-                method1697(var0, var9, var2, var3);
+        while (!lineIsEmpty && getStringWidth(fontMetrics, line) > maximumWidth) {
+            String var5 = line;
+            line = splitAtSpace(line);
+            if (line.length() == 0) {
+                line = var5;
+                lineIsEmpty = true;
             }
         }
 
-    }
+        lines.addElement(line);
+        int l = line.length();
+        if (l < text.length()) {
+            String newText = text.substring(l);
+            if (Character.isWhitespace(newText.charAt(0))) {
+                newText = newText.substring(1);
+            }
 
-    private static String method1698(String var0) {
-        int var1 = var0.lastIndexOf(32);
-        if (var1 == -1) {
-            var1 = var0.length() - 1;
+            if (newText.length() > 0) {
+                createLinesPrivate(lines, newText, fontMetrics, maximumWidth);
+            }
         }
 
-        return var0.substring(0, var1);
+    }
+
+    private static String splitAtSpace(String line) {
+        int spaceLocation = line.lastIndexOf(' ');
+        if (spaceLocation == -1) {
+            spaceLocation = line.length() - 1;
+        }
+
+        return line.substring(0, spaceLocation);
     }
 }

--- a/client/src/main/java/com/aapeli/colorgui/Choicer.java
+++ b/client/src/main/java/com/aapeli/colorgui/Choicer.java
@@ -12,193 +12,191 @@ import java.util.Vector;
 
 public class Choicer extends IPanel implements ComponentListener, ItemListener, ItemSelectable {
 
-    private Choice aChoice3248 = new Choice();
+    private Choice choice = new Choice();
     private ColorSpinner colorSpinner;
     private boolean choiceMode = true;
-    private Vector aVector3251;
-    private Object anObject3252 = new Object();
+    private Vector<ItemListener> listeners;
+    private Object synchronizationObject = new Object();
 
 
     public Choicer() {
-        this.aChoice3248.setBackground(Color.white);
-        this.aChoice3248.setForeground(Color.black);
-        this.aChoice3248.addItemListener(this);
-        this.aVector3251 = new Vector();
-        this.setLayout((LayoutManager) null);
-        this.aChoice3248.setLocation(0, 0);
-        this.add(this.aChoice3248);
+        this.choice.setBackground(Color.white);
+        this.choice.setForeground(Color.black);
+        this.choice.addItemListener(this);
+        this.listeners = new Vector<>();
+        this.setLayout(null);
+        this.choice.setLocation(0, 0);
+        this.add(this.choice);
         this.addComponentListener(this);
     }
 
-    public void componentHidden(ComponentEvent var1) {
+    public void componentHidden(ComponentEvent e) {
     }
 
-    public void componentShown(ComponentEvent var1) {
+    public void componentShown(ComponentEvent e) {
     }
 
-    public void componentMoved(ComponentEvent var1) {
+    public void componentMoved(ComponentEvent e) {
     }
 
-    public void componentResized(ComponentEvent var1) {
-        Object var2 = this.anObject3252;
-        synchronized (this.anObject3252) {
-            Dimension var3 = this.getSize();
+    public void componentResized(ComponentEvent e) {
+        Object synchronizationObject = this.synchronizationObject;
+        synchronized (this.synchronizationObject) {
+            Dimension size = this.getSize();
             if (this.choiceMode) {
-                this.aChoice3248.setSize(var3);
+                this.choice.setSize(size);
             } else {
-                this.colorSpinner.setSize(var3);
+                this.colorSpinner.setSize(size);
             }
 
         }
     }
 
-    public void itemStateChanged(ItemEvent var1) {
-        Vector var2 = this.aVector3251;
-        synchronized (this.aVector3251) {
-            if (!this.aVector3251.isEmpty()) {
-                var1 = new ItemEvent(this, var1.getID(), var1.getItem(), var1.getStateChange());
-                Enumeration var3 = this.aVector3251.elements();
+    public void itemStateChanged(ItemEvent e) {
+        Vector<ItemListener> listeners = this.listeners;
+        synchronized (this.listeners) {
+            if (!this.listeners.isEmpty()) {
+                e = new ItemEvent(this, e.getID(), e.getItem(), e.getStateChange());
+                Enumeration<ItemListener> listenerEnumeration = this.listeners.elements();
 
-                while (var3.hasMoreElements()) {
-                    ((ItemListener) ((ItemListener) var3.nextElement())).itemStateChanged(var1);
+                while (listenerEnumeration.hasMoreElements()) {
+                    listenerEnumeration.nextElement().itemStateChanged(e);
                 }
-
             }
         }
     }
 
     public Object[] getSelectedObjects() {
-        Object var1 = this.anObject3252;
-        synchronized (this.anObject3252) {
-            return this.choiceMode ? this.aChoice3248.getSelectedObjects() : this.colorSpinner.getSelectedObjects();
+        Object synchronizationObject = this.synchronizationObject;
+        synchronized (this.synchronizationObject) {
+            return this.choiceMode ? this.choice.getSelectedObjects() : this.colorSpinner.getSelectedObjects();
         }
     }
 
-    public void setBackground(Color var1) {
-        Object var2 = this.anObject3252;
-        synchronized (this.anObject3252) {
-            super.setBackground(var1);
+    public void setBackground(Color color) {
+        Object synchronizationObject = this.synchronizationObject;
+        synchronized (this.synchronizationObject) {
+            super.setBackground(color);
             if (this.choiceMode) {
-                this.aChoice3248.setBackground(var1);
+                this.choice.setBackground(color);
             } else {
-                this.colorSpinner.setBackground(var1);
+                this.colorSpinner.setBackground(color);
             }
 
         }
     }
 
-    public void setForeground(Color var1) {
-        Object var2 = this.anObject3252;
-        synchronized (this.anObject3252) {
-            super.setForeground(var1);
+    public void setForeground(Color color) {
+        Object synchronizationObject = this.synchronizationObject;
+        synchronized (this.synchronizationObject) {
+            super.setForeground(color);
             if (this.choiceMode) {
-                this.aChoice3248.setForeground(var1);
+                this.choice.setForeground(color);
             } else {
-                this.colorSpinner.setForeground(var1);
+                this.colorSpinner.setForeground(color);
             }
 
         }
     }
 
-    public void addItem(String var1) {
-        Object var2 = this.anObject3252;
-        synchronized (this.anObject3252) {
+    public void addItem(String text) {
+        Object synchronizationObject = this.synchronizationObject;
+        synchronized (this.synchronizationObject) {
             if (this.choiceMode) {
-                this.method825(var1);
+                this.moveToSpinnerIfNecessary(text);
             }
 
             if (this.choiceMode) {
-                this.aChoice3248.addItem(var1);
+                this.choice.addItem(text);
             } else {
-                this.colorSpinner.addItem(var1);
+                this.colorSpinner.addItem(text);
             }
 
         }
     }
 
-    public void removeItem(int var1) {
-        Object var2 = this.anObject3252;
-        synchronized (this.anObject3252) {
+    public void removeItem(int i) {
+        Object synchronizationObject = this.synchronizationObject;
+        synchronized (this.synchronizationObject) {
             if (this.choiceMode) {
-                this.aChoice3248.remove(var1);
+                this.choice.remove(i);
             } else {
-                this.colorSpinner.removeItem(var1);
+                this.colorSpinner.removeItem(i);
             }
 
         }
     }
 
     public int getItemCount() {
-        Object var1 = this.anObject3252;
-        synchronized (this.anObject3252) {
-            return this.choiceMode ? this.aChoice3248.getItemCount() : this.colorSpinner.getItemCount();
+        Object synchronizationObject = this.synchronizationObject;
+        synchronized (this.synchronizationObject) {
+            return this.choiceMode ? this.choice.getItemCount() : this.colorSpinner.getItemCount();
         }
     }
 
     public int getSelectedIndex() {
-        Object var1 = this.anObject3252;
-        synchronized (this.anObject3252) {
-            return this.choiceMode ? this.aChoice3248.getSelectedIndex() : this.colorSpinner.getSelectedIndex();
+        Object synchronizationObject = this.synchronizationObject;
+        synchronized (this.synchronizationObject) {
+            return this.choiceMode ? this.choice.getSelectedIndex() : this.colorSpinner.getSelectedIndex();
         }
     }
 
-    public void select(int var1) {
-        this.setSelectedIndex(var1);
+    public void select(int i) {
+        this.setSelectedIndex(i);
     }
 
-    public void setSelectedIndex(int var1) {
-        Object var2 = this.anObject3252;
-        synchronized (this.anObject3252) {
+    public void setSelectedIndex(int i) {
+        Object synchronizationObject = this.synchronizationObject;
+        synchronized (this.synchronizationObject) {
             if (this.choiceMode) {
-                this.aChoice3248.select(var1);
+                this.choice.select(i);
             } else {
-                this.colorSpinner.setSelectedIndex(var1);
+                this.colorSpinner.setSelectedIndex(i);
             }
 
         }
     }
 
-    public void addItemListener(ItemListener var1) {
-        Vector var2 = this.aVector3251;
-        synchronized (this.aVector3251) {
-            this.aVector3251.addElement(var1);
+    public void addItemListener(ItemListener listener) {
+        Vector<ItemListener> listeners = this.listeners;
+        synchronized (this.listeners) {
+            this.listeners.addElement(listener);
         }
     }
 
     public void removeItemListener(ItemListener var1) {
-        Vector var2 = this.aVector3251;
-        synchronized (this.aVector3251) {
-            this.aVector3251.removeElement(var1);
+        Vector<ItemListener> listeners = this.listeners;
+        synchronized (this.listeners) {
+            this.listeners.removeElement(var1);
         }
     }
 
     public void moveToSpinner() {
-        Object var1 = this.anObject3252;
-        synchronized (this.anObject3252) {
+        Object synchronizationObject = this.synchronizationObject;
+        synchronized (this.synchronizationObject) {
             if (this.choiceMode) {
                 this.colorSpinner = new ColorSpinner();
                 this.colorSpinner.setLocation(0, 0);
                 this.colorSpinner.setSize(this.getSize());
-                this.colorSpinner.setBackground(this.aChoice3248.getBackground());
-                this.colorSpinner.setForeground(this.aChoice3248.getForeground());
-                int var2 = this.aChoice3248.getItemCount();
+                this.colorSpinner.setBackground(this.choice.getBackground());
+                this.colorSpinner.setForeground(this.choice.getForeground());
+                int items = this.choice.getItemCount();
 
-                int var3;
-                for (var3 = 0; var3 < var2; ++var3) {
-                    this.colorSpinner.addItem(this.aChoice3248.getItem(var3));
+                for (int i = 0; i < items; ++i) {
+                    this.colorSpinner.addItem(this.choice.getItem(i));
                 }
 
-                var3 = this.aChoice3248.getSelectedIndex();
-                if (var3 >= 0) {
-                    this.colorSpinner.setSelectedIndex(var3);
+                int selectedIndex = this.choice.getSelectedIndex();
+                if (selectedIndex >= 0) {
+                    this.colorSpinner.setSelectedIndex(selectedIndex);
                 }
 
-                this.aChoice3248.removeItemListener(this);
-                this.remove(this.aChoice3248);
+                this.choice.removeItemListener(this);
+                this.remove(this.choice);
                 this.add(this.colorSpinner);
                 this.colorSpinner.addItemListener(this);
                 this.choiceMode = false;
-                this.aChoice3248 = null;
+                this.choice = null;
             }
         }
     }
@@ -211,11 +209,11 @@ public class Choicer extends IPanel implements ComponentListener, ItemListener, 
         return this.choiceMode;
     }
 
-    private void method825(String var1) {
-        char[] var2 = var1.toCharArray();
+    private void moveToSpinnerIfNecessary(String text) {
+        char[] chars = text.toCharArray();
 
-        for (int var3 = 0; var3 < var2.length; ++var3) {
-            if (var2[var3] > 255) {
+        for (char c : chars) {
+            if (c > 255) {
                 this.moveToSpinner();
                 return;
             }

--- a/client/src/main/java/org/moparforia/client/Game.java
+++ b/client/src/main/java/org/moparforia/client/Game.java
@@ -23,7 +23,7 @@ public class Game {
         game.init();
         game.start();
         frame.add(game);
-        frame.setSize(WIDTH + 20, HEIGHT + 40);
+        frame.setSize(1280, 720);
         frame.setResizable(true);
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         frame.setVisible(true);


### PR DESCRIPTION
This PR adds the following features:
- The game is now painted in the center of the applet. Now, resizing the applet actually does something as the content is painted in the middle of it and IMO looks better. Since the game now utilizes space better, I also increased the default window size to 1280x720p.

| Before | After |
| ------ | ----- |
| <video src="https://github.com/PhilippvK/playforia-minigolf/assets/21343173/9f3f3915-a616-49c6-9cb0-8dc60b468cd0"> | <video src="https://github.com/PhilippvK/playforia-minigolf/assets/21343173/1c41e705-f9c5-41f8-a6f2-f22b6611ef13"> |

- Game audio can now be muted from the lobby selection screen. This is useful when playing multiple games on the same host to have audio only played once. To fit this on the home screen, I shifted the graphics settings up by a bit.