### PR TITLE
Upgrade to Java 21, fix Docker image, add server integration test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,3 +32,7 @@ jobs:
         run: sudo apt-get install -y genisoimage
       - name: Build with Maven
         run: mvn -B install --file pom.xml
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          tags: philippvk/minigolf:latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'temurin'
       # Step that caches and restores maven dependencies
       - name: Cache maven dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,10 @@ jobs:
         uses: metcalfc/changelog-generator@v0.4.3
         with:
           myToken: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'temurin'
       # Step that caches and restores maven dependencies
       - name: Cache maven dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,15 @@
 #
 # Build stage
 #
-FROM maven:3.6.0-jdk-8-slim AS build
+FROM maven:3.9.7-eclipse-temurin-21 AS build
 COPY . /home/app/
 RUN mvn -f /home/app/pom.xml -pl server -am clean package
 
 #
 # Package stage
 #
-FROM openjdk:8-alpine
+FROM eclipse-temurin:21-alpine
 COPY --from=build /home/app/server/target/server-*.jar /home/minigolf/server.jar
-COPY tracks/ /home/minigolf/tracks/
 EXPOSE 4242
 WORKDIR /home/minigolf
 ENTRYPOINT ["java","-jar","server.jar"]

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The Java Applet-based Minigolf Client was one of the most popular multiplayer ga
 
 ### Prerequisites
 - Clone this repo: `git clone git@github.com:PhilippvK/playforia-minigolf.git`
-- Install Java Development Kit 17 (https://adoptium.net/en-GB/temurin/releases/)
+- Install Java Development Kit 21 (https://adoptium.net/en-GB/temurin/releases/)
 - Install Apache `maven` for building: https://maven.apache.org/install.html
 - *Optional:* Install IntelliJ IDEA Java IDE (https://www.jetbrains.com/idea/download/) and import this repository as project
 
@@ -83,7 +83,7 @@ Client CLI options:
 ## Compatibility
 
 Tested:
-- Ubuntu 22.04 with Java version `17.0.6`
+- Ubuntu 22.04 with Java version `21.0.3`
 - Windows 10/11
 
 ## Problems

--- a/README.md
+++ b/README.md
@@ -62,7 +62,13 @@ java -jar client.jar -server 192.168.1.7 -lang en_US # Replace IP with the one o
 
 #### Running Minigolf Server in Docker Container
 
-We provide an experimental Dockerfile for easy hosting of the server application. You can either build the image by yourself or download the pre-build images from [quay.io](https://quay.io/repository/philippvk/minigolf) via `docker pull quay.io/philippvk/minigolf:latest`.
+We provide an experimental Dockerfile for easy hosting of the server application. 
+You can either build and run the image:
+```sh
+docker build -t pfmg .
+docker run pfmg
+```
+or download the pre-built images from [quay.io](https://quay.io/repository/philippvk/minigolf) via `docker pull quay.io/philippvk/minigolf:latest`.
 
 Running the Editor is quite straightforward as it can be started like expected: `java -jar editor.jar`
 

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -84,7 +84,7 @@
             <plugin>
                 <groupId>com.googlecode.maven-download-plugin</groupId>
                 <artifactId>download-maven-plugin</artifactId>
-                <version>1.6.8</version>
+                <version>1.9.0</version>
                 <executions>
                     <execution>
                       <id>download-osx-jre</id>
@@ -104,7 +104,6 @@
             <plugin>
                 <groupId>sh.tak.appbundler</groupId>
                 <artifactId>appbundle-maven-plugin</artifactId>
-                <version>1.2.0</version>
                 <configuration>
                     <bundleName>${project.name}</bundleName>
                     <iconFile>src/main/resources/icons/playforia.icns</iconFile>
@@ -133,7 +132,6 @@
             <plugin>
                 <groupId>com.akathist.maven.plugins.launch4j</groupId>
                 <artifactId>launch4j-maven-plugin</artifactId>
-                <version>2.3.3</version>
                 <executions>
                     <execution>
                         <id>windows-build</id>
@@ -174,7 +172,7 @@
             <plugin>
                 <artifactId>plantuml-generator-maven-plugin</artifactId>
                 <groupId>de.elnarion.maven</groupId>
-                <version>1.1.2</version>
+                <version>2.4.1</version>
                 <executions>
                     <execution>
                         <id>generate-simple-diagram</id>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -15,8 +15,8 @@
         <project.mainClass>org.moparforia.client.Launcher</project.mainClass>
         <project.name>Playforia Minigolf Client</project.name>
         <project.download.directory>${project.build.directory}/downloads</project.download.directory>
-        <project.jre.osx.link>https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.7%2B7/OpenJDK17U-jre_x64_mac_hotspot_17.0.7_7.tar.gz</project.jre.osx.link>
-        <project.jre.osx.name>jdk-17.0.7+7-jre</project.jre.osx.name>
+        <project.jre.osx.link>https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jre_aarch64_mac_hotspot_21.0.2_13.tar.gz</project.jre.osx.link>
+        <project.jre.osx.name>jdk-21.0.2+13-jre</project.jre.osx.name>
     </properties>
 
     <dependencies>
@@ -154,7 +154,7 @@
                             <icon>src/main/resources/icons/playforia.ico</icon>
                             <jre>
                                 <path>jre</path>
-                                <minVersion>17</minVersion>
+                                <minVersion>21</minVersion>
                             </jre>
                             <versionInfo>
                                 <fileVersion>1.0.0.0</fileVersion>

--- a/client/src/test/java/org/moparforia/client/LauncherCLITest.java
+++ b/client/src/test/java/org/moparforia/client/LauncherCLITest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.quality.Strictness;
 import picocli.CommandLine;
 
 import javax.swing.JFrame;
@@ -42,7 +43,7 @@ class LauncherCLITest {
     void setUp() throws Exception {
         // Mock game
         launcher = mock(Launcher.class, withSettings()
-                .lenient()
+                .strictness(Strictness.LENIENT)
                 .withoutAnnotations());
 
         // Use real methods

--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.11.0</version>
                     <configuration>
-                        <source>17</source>
-                        <target>17</target>
+                        <source>21</source>
+                        <target>21</target>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
                                         </manifestEntries>
                                     </transformer>
                                 </transformers>
+                                <createDependencyReducedPom>false</createDependencyReducedPom>
                             </configuration>
                         </execution>
                     </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -127,12 +127,6 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.softsmithy.lib</groupId>
-                <artifactId>softsmithy-lib-core</artifactId>
-                <version>2.1.1</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>de.elnarion.util</groupId>
                 <artifactId>plantuml-generator-util</artifactId>
                 <version>1.1.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,11 @@
     <packaging>pom</packaging>
     <version>2.1.2.0-BETA</version>
     <name>Playforia Minigolf</name>
+    <organization>
+        <name>Playforia</name>
+    </organization>
+    <inceptionYear>2002</inceptionYear>
+    <description>An online multiplayer minigolf game</description>
 
     <modules>
         <module>server</module>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.mainClass>test.mainClass</project.mainClass>
-        <picocli.version>4.5.2</picocli.version>
+        <picocli.version>4.7.6</picocli.version>
     </properties>
     <build>
         <pluginManagement>
@@ -31,7 +31,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.11.0</version>
+                    <version>3.13.0</version>
                     <configuration>
                         <source>21</source>
                         <target>21</target>
@@ -40,7 +40,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.2.4</version>
+                    <version>3.5.3</version>
                     <executions>
                         <execution>
                             <phase>package</phase>
@@ -73,16 +73,20 @@
                 <plugin>
                     <groupId>com.akathist.maven.plugins.launch4j</groupId>
                     <artifactId>launch4j-maven-plugin</artifactId>
-                    <version>1.7.25</version>
+                    <version>2.5.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.2</version>
+                    <version>3.2.5</version>
+                    <configuration>
+                        <argLine>-XX:+EnableDynamicAgentLoading</argLine>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -111,31 +115,31 @@
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
-                <version>5.6.2</version>
+                <version>5.10.2</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>3.5.10</version>
+                <version>5.12.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-junit-jupiter</artifactId>
-                <version>3.5.10</version>
+                <version>5.12.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>com.github.marschall</groupId>
                 <artifactId>memoryfilesystem</artifactId>
-                <version>2.1.0</version>
+                <version>2.8.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>de.elnarion.util</groupId>
                 <artifactId>plantuml-generator-util</artifactId>
-                <version>1.1.2</version>
+                <version>2.4.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -81,7 +81,7 @@
             <plugin>
                 <artifactId>plantuml-generator-maven-plugin</artifactId>
                 <groupId>de.elnarion.maven</groupId>
-                <version>1.1.2</version>
+                <version>2.4.1</version>
                 <executions>
                     <execution>
                         <id>generate-simple-diagram</id>

--- a/server/src/main/java/org/moparforia/server/Server.java
+++ b/server/src/main/java/org/moparforia/server/Server.java
@@ -50,6 +50,9 @@ public class Server implements Runnable {
     private int port;
     private Optional<String> tracksDirectory;
 
+    private Channel serverChannel;
+    private boolean running;
+
     private HashMap<LobbyType, Lobby> lobbies = new HashMap<LobbyType, Lobby>();
     //private ArrayList<LobbyRef> lobbies = new ArrayList<LobbyRef>();
     //private HashMap<Integer, Game> games = new HashMap<Integer, Game>();
@@ -188,17 +191,23 @@ public class Server implements Runnable {
         bootstrap.setOption("child.tcpNoDelay", true);
         bootstrap.setOption("child.keepAlive", true);
         try {
-            bootstrap.bind(new InetSocketAddress(host, port));
+            this.serverChannel = bootstrap.bind(new InetSocketAddress(host, port));
+            this.running = true;
             new Thread(this).start();
         } catch (Exception ex) {
             ex.printStackTrace();
         }
     }
 
+    public void stop() throws InterruptedException {
+        this.serverChannel.close().sync();
+        this.running = false;
+    }
+
     @Override
     public void run() {
         System.out.println("Started server on host " + this.host + " with port " + this.port);
-        while (true) {
+        while (this.running) {
             try {
                 Thread.sleep(10);
                 Iterator<Event> iterator = events.iterator();

--- a/server/src/main/java/org/moparforia/server/event/ClientDisconnectedEvent.java
+++ b/server/src/main/java/org/moparforia/server/event/ClientDisconnectedEvent.java
@@ -18,7 +18,7 @@ public class ClientDisconnectedEvent extends Event {
         Player player;
         if ((player = (Player)channel.getAttachment()) != null) {
             if (player.getLobby() != null) {
-              player.getLobby().removePlayer(player, Lobby.PART_REASON_USERLEFT,null);
+              player.getLobby().removePlayer(player, Lobby.PART_REASON_USERLEFT);
             }
         }
         System.out.println("Client disconnected: " + channel);

--- a/server/src/main/java/org/moparforia/server/net/packethandlers/QuitHandler.java
+++ b/server/src/main/java/org/moparforia/server/net/packethandlers/QuitHandler.java
@@ -28,7 +28,7 @@ public class QuitHandler implements PacketHandler {
     public boolean handle(Server server, Packet packet, Matcher message) {
         Player player = (Player) packet.getChannel().getAttachment();
         if (message.group(1).contains("lobby")) {
-            player.getLobby().removePlayer(player, Lobby.PART_REASON_USERLEFT, null);
+            player.getLobby().removePlayer(player, Lobby.PART_REASON_USERLEFT);
         }
         packet.getChannel().disconnect();
         packet.getChannel().close();

--- a/server/src/test/java/org/moparforia/server/ServerTest.java
+++ b/server/src/test/java/org/moparforia/server/ServerTest.java
@@ -1,0 +1,117 @@
+package org.moparforia.server;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.net.Socket;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ServerTest {
+
+    private void sendMessage(BufferedWriter writer, String message) throws IOException {
+        writer.write(message);
+        writer.newLine();
+        writer.flush();
+    }
+
+    @Test
+    void testSinglePlayerFlow() throws IOException, InterruptedException {
+        Server server = new Server("127.0.0.1", 4243, Optional.empty());
+        server.start();
+
+        Socket socket = new Socket("127.0.0.1", 4243);
+        InputStream in = socket.getInputStream();
+        OutputStream out = socket.getOutputStream();
+        InputStreamReader r = new InputStreamReader(in);
+        OutputStreamWriter w = new OutputStreamWriter(out);
+        BufferedReader reader = new BufferedReader(r);
+        BufferedWriter writer = new BufferedWriter(w);
+
+        // init
+        String h = reader.readLine();
+        String cIo = reader.readLine();
+        String cCrt = reader.readLine();
+        String cCtr = reader.readLine();
+        assertEquals("h 1", h);
+        assertTrue(cIo.matches("c io \\d+"));
+        assertEquals("c crt 250", cCrt);
+        assertEquals("c ctr", cCtr);
+
+        String nickname = "nick";
+
+        // client id
+        this.sendMessage(writer, "c new");
+        String cId = reader.readLine();
+        assertEquals("c id 0", cId);
+
+        // version
+        this.sendMessage(writer, "d 0 version\t35");
+        String statusLogin = reader.readLine();
+        assertEquals("d 0 status\tlogin", statusLogin);
+
+        // login
+        this.sendMessage(writer, "d 1 ttlogin\t" + nickname + "\t");
+        String basicInfo = reader.readLine();
+        String statusLobbyselect = reader.readLine();
+        assertEquals("d 1 basicinfo\tt\t0\tt\tf", basicInfo);
+        assertEquals("d 2 status\tlobbyselect\t300", statusLobbyselect);
+
+        // number of players
+        this.sendMessage(writer, "d 2 lobbyselect\trnop");
+        String lobbySelectNop = reader.readLine();
+        assertEquals("d 3 lobbyselect\tnop\t0\t0\t0", lobbySelectNop);
+
+        // select single player
+        this.sendMessage(writer, "d 3 lobbyselect\tselect\t1");
+        String statusLobby = reader.readLine();
+        String lobbyUsers = reader.readLine();
+        String lobbyOwnjoin = reader.readLine();
+        assertEquals("d 4 status\tlobby\t1", statusLobby);
+        assertEquals("d 5 lobby\tusers", lobbyUsers);
+        assertEquals("d 6 lobby\townjoin\t3:" + nickname + "^w^10000^-^-^-", lobbyOwnjoin);
+        this.sendMessage(writer, "d 4 lobby\ttracksetlist");
+        String tracksetlist = reader.readLine();
+        assertEquals(tracksetlist, "d 7 lobby\ttracksetlist\tBirchwood\t1\t9\tNo one\t1\tNo one\t1\tNo one\t1\tNo one\t1\tOak Park\t1\t18\tNo one\t1\tNo one\t1\tNo one\t1\tNo one\t1\tOne by One\t2\t18\tNo one\t1\tNo one\t1\tNo one\t1\tNo one\t1\tScary Set\t3\t9\tNo one\t1\tNo one\t1\tNo one\t1\tNo one\t1\tSpruce Corpse\t2\t9\tNo one\t1\tNo one\t1\tNo one\t1\tNo one\t1\tThe First\t2\t18\tNo one\t1\tNo one\t1\tNo one\t1\tNo one\t1\tTorment Fields\t3\t18\tNo one\t1\tNo one\t1\tNo one\t1\tNo one\t1");
+
+        // start championship game
+        this.sendMessage(writer, "d 5 lobby\tcspc\t6");
+        String statusGame = reader.readLine();
+        String gameInfo = reader.readLine();
+        String players = reader.readLine();
+        String ownInfo = reader.readLine();
+        String gameStart = reader.readLine();
+        String resetVoteSkip = reader.readLine();
+        String startTrack = reader.readLine();
+        String startTurn = reader.readLine();
+        assertEquals("d 8 status\tgame", statusGame);
+        assertEquals("d 9 game\tgameinfo\tderp\tf\t0\t1\t18\t0\t0\t0\t0\t1\t0\t0\tf", gameInfo);
+        assertEquals("d 10 game\tplayers", players);
+        assertEquals("d 11 game\towninfo\t0\t" + nickname + "\t-", ownInfo);
+        assertEquals("d 12 game\tstart", gameStart);
+        assertEquals("d 13 game\tresetvoteskip", resetVoteSkip);
+        assertTrue(startTrack.matches("d 14 game\tstarttrack\tt\t0\tV 1\tA Leonardo\tN Revocations\tT BAMM21DBAQQ7DBAMM18DBAQQDB3ADDBAQQ6DEDDBAQQ7DB3A11DBHAQBGAQB3ABAQQ4DB3ADDBHAMEDEB3A10DEDDB3A3DBHAQBGAQB3AEE14DBAGABAIADDBAKAE3DEDEE10DEDDE6DEE6DBAQQE6DEEDDEE3DEDEE10DEDDE4DBIAHBAIAEE6DEE6DEEDDEE3DEDEE10DEDDE4DBAGA3EDBGMABHMAEDDEE6DEEDDEE3DEDEE10DEDDE4D4EDBHAMBGAMEDDEE6DEEDDEE3DEDEE10DEDDE4D4E6DEE6DEEDDEE3DEDEE9DBGLABAEADDBHFAE3DBAQQ3E6DEE6DEEDDEE3DEDEE9DBAKAGDDBAGAE3D4E6DEEDBAQQ6DEG7DBAMMEDBEAQBFAQE5DEEDDEE3D4E6DEE5DEDDEE7DEEDBHAQBAQQDE4DEEDDEE3DEBAGADE6DEE5DEG9D3EDDEBGAQE4DEEDDEE3DEDDE6DEE5DEE9DEBAQQE9DEEDDEE5DEE6DEE5DBGAQE9D3E9DEEDDEE5DEE4DBAQQDDE16D3E5DBAQQ4DEDDBAQQ7DE4DEBAGADE5DBEAQBAQQDDBGAQEDDBGMABAMMDDEBFAQE4DEBAMM3DEDDBAMA7DE4DEBAEAGE5DBAQQBGAQH4DBGMABAMM3DEDFE3DEE3DEDDE7DE4D4E5DEG5DBHAMEBGAMB3ABAQQEDDFEDDEEBIMAB3A17D4E5DEE6DBSAMGDEE3DFEDEEB3A18DBAGA3E5DEE9DEEBIQAB3A4DEEBLMAE17D4EDDBQAMEDEE9DEEB3ACBAE3DEE3DEDDBAMA7DE4D4EDBEAMBAMMBFAM3E7DCAA3EBLQAF4DEE3DEDDE7DEDBEAQBFAQ5EBEAMBAMMDBEMA3E9DEE11DEDDBAQQ15DBAMMDDBEMAB3ADE11DBAMM10DE4DBAMM32D,Ads:C0204\tI 308939,4480252,4,2203\tB d2b,\\d+\tR 633,173,118,129,125,546,495,461,467,556,4472"));
+        assertEquals("d 15 game\tstartturn\t0", startTurn);
+
+        // leave game
+        this.sendMessage(writer, "d 6 game\tback");
+        statusLobby = reader.readLine();
+        lobbyUsers = reader.readLine();
+        lobbyOwnjoin = reader.readLine();
+        assertEquals("d 16 status\tlobby\t1", statusLobby);
+        assertEquals("d 17 lobby\tusers", lobbyUsers);
+        assertEquals("d 18 lobby\townjoin\t3:" + nickname + "^w^10000^-^-^-", lobbyOwnjoin);
+
+        // quit game
+        this.sendMessage(writer, "d 7 lobby\tquit");
+        server.stop();
+    }
+}

--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -48,7 +48,7 @@
             <plugin>
                 <artifactId>plantuml-generator-maven-plugin</artifactId>
                 <groupId>de.elnarion.maven</groupId>
-                <version>1.1.2</version>
+                <version>2.4.1</version>
                 <executions>
                     <execution>
                         <id>generate-simple-diagram</id>

--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -38,11 +38,6 @@
             <artifactId>memoryfilesystem</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.softsmithy.lib</groupId>
-            <artifactId>softsmithy-lib-core</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/shared/src/main/java/org/moparforia/shared/tracks/filesystem/FileSystemTrackManager.java
+++ b/shared/src/main/java/org/moparforia/shared/tracks/filesystem/FileSystemTrackManager.java
@@ -95,7 +95,7 @@ public class FileSystemTrackManager implements TrackManager {
             Scanner scanner = new Scanner(filePath);
             String setName = scanner.nextLine();
             TrackSetDifficulty trackSetDifficulty = TrackSetDifficulty.valueOf(scanner.nextLine());
-            List<String> trackNames = new ArrayList<String>();
+            List<String> trackNames = new ArrayList<>();
             while (scanner.hasNextLine()) {
                 String line = scanner.nextLine().trim();
                 if (!line.isEmpty()) {
@@ -106,8 +106,9 @@ public class FileSystemTrackManager implements TrackManager {
             // Convert fileNames to already loaded tracks
             List<Track> tracks = getTracks().stream()
                     .filter(track -> trackNames.contains(track.getName()))
+                    .sorted(Comparator.comparing((track) -> trackNames.indexOf(track.getName())))
                     .collect(Collectors.toList());
-            if (tracks.size() < 1) {
+            if (tracks.isEmpty()) {
                 logger.warning("TrackSet " + setName + " has no valid tracks associated with it, ignoring");
                 continue;
             }
@@ -119,6 +120,7 @@ public class FileSystemTrackManager implements TrackManager {
             }
             trackSets.add(new TrackSet(setName, trackSetDifficulty, tracks));
         }
+        trackSets.sort(Comparator.comparing(TrackSet::getName));
         return trackSets;
     }
 

--- a/shared/src/test/java/org/moparforia/shared/tracks/util/FileSystemExtension.java
+++ b/shared/src/test/java/org/moparforia/shared/tracks/util/FileSystemExtension.java
@@ -4,7 +4,6 @@ import com.github.marschall.memoryfilesystem.MemoryFileSystemBuilder;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.softsmithy.lib.nio.file.CopyFileVisitor;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -43,7 +42,7 @@ public class FileSystemExtension implements BeforeEachCallback, AfterEachCallbac
     public void copyFile(String src) throws IOException, URISyntaxException {
         Path srcPath = getRootDir().resolve(src);
         Path targetPath = fileSystem.getPath(src);
-        CopyFileVisitor.copy(srcPath, targetPath);
+        Files.copy(srcPath, targetPath);
     }
 
     /**
@@ -58,7 +57,7 @@ public class FileSystemExtension implements BeforeEachCallback, AfterEachCallbac
                 .collect(Collectors.toList());
         for (Path file : files) {
             Path relative_path = fileSystem.getPath(base.relativize(file).toString().replace(FileSystems.getDefault().getSeparator(), fileSystem.getSeparator()));
-            CopyFileVisitor.copy(base.resolve(file), relative_path);
+            Files.copy(base.resolve(file), relative_path);
         }
     }
 


### PR DESCRIPTION
This PR is a collection of smaller changes:
- The project is upgraded to the latest Java LTS version, Java 21. Features added since Java 17 include things like pattern matching, unnamed variables, and UTF-8 as the charset.
- An integration test with a mocked client was added to the server to verify it's working as expected. This will be useful later when upgrading the server to Netty 4.1 to avoid breaking anything.
  - The testing revealed that previously messages sent from the server non-deterministic, i.e. sometimes TrackSets and Tracks were sent in one order and sometimes in another. Now these are sorted in the server to ensure the same message is sent every time and tests pass. This also fixes a bug where championship games did not run in the intended order and the games could start with the hardest tracks in the championship first.
- The server Docker image was fixed and is now built in CI to ensure it won't break again. I accidentally broke it when upgrading the project to Java 17 earlier.
- A bunch of dependencies were upgraded and warnings fixed to make build logs more readable.