### PR TITLE
Server: Upgrade Netty to version 4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,8 +96,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.netty</groupId>
-                <artifactId>netty</artifactId> <!-- Use 'netty-all' for 4.0 or above -->
-                <version>3.10.6.Final</version>
+                <artifactId>netty-all</artifactId>
+                <version>4.1.112.Final</version>
                 <scope>compile</scope>
             </dependency>
             <dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -19,7 +19,7 @@
     <dependencies>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty</artifactId> <!-- Use 'netty-all' for 4.0 or above -->
+            <artifactId>netty-all</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/server/src/main/java/org/moparforia/server/event/ClientConnectedEvent.java
+++ b/server/src/main/java/org/moparforia/server/event/ClientConnectedEvent.java
@@ -1,6 +1,6 @@
 package org.moparforia.server.event;
 
-import org.jboss.netty.channel.Channel;
+import io.netty.channel.Channel;
 import org.moparforia.server.Server;
 
 import java.util.Random;
@@ -17,8 +17,7 @@ public class ClientConnectedEvent extends Event {
     public void process(Server server) {
         System.out.println("Client connected: " + channel);
         server.addChannel(channel);
-        //channel.write("h 1\nc io " + new Random().nextInt(1000000000) + "\nc crt 25\nc ctr\n");
-        channel.write("h 1\nc io " + new Random().nextInt(1000000000) + "\nc crt 250\nc ctr\n");
+        channel.writeAndFlush("h 1\nc io " + new Random().nextInt(1000000000) + "\nc crt 250\nc ctr\n");
     }
 
 }

--- a/server/src/main/java/org/moparforia/server/event/ClientDisconnectedEvent.java
+++ b/server/src/main/java/org/moparforia/server/event/ClientDisconnectedEvent.java
@@ -1,6 +1,6 @@
 package org.moparforia.server.event;
 
-import org.jboss.netty.channel.Channel;
+import io.netty.channel.Channel;
 import org.moparforia.server.Server;
 import org.moparforia.server.game.Lobby;
 import org.moparforia.server.game.Player;
@@ -15,8 +15,8 @@ public class ClientDisconnectedEvent extends Event {
 
     @Override
     public void process(Server server) {
-        Player player;
-        if ((player = (Player)channel.getAttachment()) != null) {
+        Player player = channel.attr(Player.PLAYER_ATTRIBUTE_KEY).get();
+        if (player != null) {
             if (player.getLobby() != null) {
               player.getLobby().removePlayer(player, Lobby.PART_REASON_USERLEFT);
             }

--- a/server/src/main/java/org/moparforia/server/game/Game.java
+++ b/server/src/main/java/org/moparforia/server/game/Game.java
@@ -1,6 +1,6 @@
 package org.moparforia.server.game;
 
-import org.jboss.netty.channel.Channel;
+import io.netty.channel.Channel;
 import org.moparforia.server.Server;
 import org.moparforia.server.game.gametypes.golf.MultiGame;
 import org.moparforia.server.net.Packet;
@@ -102,7 +102,7 @@ public abstract class Game extends PlayerCollection {
         sendGameInfo(player);
         sendPlayerNames(player);
         writeExcluding(player, new Packet(PacketType.DATA, Tools.tabularize("game", "join", playerCount(), player.getNick(), player.getClan())));
-        player.getChannel().write(new Packet(PacketType.DATA, Tools.tabularize("game", "owninfo", numberIndex, player.getNick(), player.getClan())));
+        player.getChannel().writeAndFlush(new Packet(PacketType.DATA, Tools.tabularize("game", "owninfo", numberIndex, player.getNick(), player.getClan())));
     }
 
     protected void sendPlayerNames(Player player) {
@@ -112,7 +112,7 @@ public abstract class Game extends PlayerCollection {
             if (!p.equals(player))
                 playersData += Tools.tabularize("", getPlayerId(p), p.getNick(), p.getClan());
         }
-        c.write(new Packet(PacketType.DATA, playersData));
+        c.writeAndFlush(new Packet(PacketType.DATA, playersData));
     }
 
 

--- a/server/src/main/java/org/moparforia/server/game/Lobby.java
+++ b/server/src/main/java/org/moparforia/server/game/Lobby.java
@@ -45,7 +45,7 @@ public class Lobby extends PlayerCollection {
         writeAll(new Packet(PacketType.DATA, cmd));
 
         if (player.getChannel().isWritable() && partReason == PART_REASON_USERLEFT) {
-            player.getChannel().write(new Packet(PacketType.DATA, "status\tlobbyselect\t300"));
+            player.getChannel().writeAndFlush(new Packet(PacketType.DATA, "status\tlobbyselect\t300"));
         }
         return true;
     }
@@ -54,23 +54,23 @@ public class Lobby extends PlayerCollection {
         if (player.getLobby() != null) {
             player.getLobby().removePlayer(player, PART_REASON_USERLEFT);
         }
-        player.getChannel().write(new Packet(PacketType.DATA, Tools.tabularize("status", "lobby", type + (player.isChatHidden() ? "h" : ""))));
+        player.getChannel().writeAndFlush(new Packet(PacketType.DATA, Tools.tabularize("status", "lobby", type + (player.isChatHidden() ? "h" : ""))));
         String[] otherPlayers = new String[playerCount()];
         int pointer = 0;
 
         for (Player p : getPlayers()) {
-            p.getChannel().write(new Packet(PacketType.DATA, Tools.tabularize(
+            p.getChannel().writeAndFlush(new Packet(PacketType.DATA, Tools.tabularize(
                     "lobby", joinType == JOIN_TYPE_NORMAL ? "join" : "joinfromgame", player.toString()//todo not sure if should be getNick or getGameString
             )));
             otherPlayers[pointer++] = p.toString();
         }
         if (pointer != 0) {
-            player.getChannel().write(new Packet(PacketType.DATA, Tools.tabularize("lobby", "users", otherPlayers)));
+            player.getChannel().writeAndFlush(new Packet(PacketType.DATA, Tools.tabularize("lobby", "users", otherPlayers)));
         } else {
-            player.getChannel().write(new Packet(PacketType.DATA, Tools.tabularize("lobby", "users")));
+            player.getChannel().writeAndFlush(new Packet(PacketType.DATA, Tools.tabularize("lobby", "users")));
         }
 
-        player.getChannel().write(new Packet(PacketType.DATA, Tools.tabularize("lobby", "ownjoin", player.toString())));
+        player.getChannel().writeAndFlush(new Packet(PacketType.DATA, Tools.tabularize("lobby", "ownjoin", player.toString())));
         if (getLobbyType() == LobbyType.MULTI) {
             sendGameList(player);
         }
@@ -89,7 +89,7 @@ public class Lobby extends PlayerCollection {
                 length++;
             }
         }
-        player.getChannel().write(new Packet(PacketType.DATA, Tools.tabularize("lobby", "gamelist", "full", length, buff.toString())));
+        player.getChannel().writeAndFlush(new Packet(PacketType.DATA, Tools.tabularize("lobby", "gamelist", "full", length, buff.toString())));
     }
 
     public Game getGame(int id) {

--- a/server/src/main/java/org/moparforia/server/game/Player.java
+++ b/server/src/main/java/org/moparforia/server/game/Player.java
@@ -1,10 +1,12 @@
 package org.moparforia.server.game;
 
-import org.jboss.netty.channel.Channel;
+import io.netty.channel.Channel;
+import io.netty.util.AttributeKey;
 import org.moparforia.shared.Tools;
 
 public class Player {
 
+    public static final AttributeKey<Player> PLAYER_ATTRIBUTE_KEY = AttributeKey.newInstance("PLAYER_ATTRIBUTE");
     public static final int ACCESSLEVEL_NORMAL = 0; // todo: enum this ?
     public static final int ACCESSLEVEL_SHERIFF = 1;
     public static final int ACCESSLEVEL_ADMIN = 2;

--- a/server/src/main/java/org/moparforia/server/game/PlayerCollection.java
+++ b/server/src/main/java/org/moparforia/server/game/PlayerCollection.java
@@ -34,20 +34,20 @@ public class PlayerCollection {
 
     public void writeAll(Packet packet) {
         for (Player player : getPlayers()) {
-            player.getChannel().write(packet);
+            player.getChannel().writeAndFlush(packet);
         }
     }
 
     public void writeAll(String message) {
         for (Player player : getPlayers()) {
-            player.getChannel().write(message);
+            player.getChannel().writeAndFlush(message);
         }
     }
 
     public void writeExcluding(Player exclude, Packet packet) {
         for (Player player : getPlayers()) {
             if (player != exclude) {
-                player.getChannel().write(packet);
+                player.getChannel().writeAndFlush(packet);
             }
         }
     }
@@ -55,7 +55,7 @@ public class PlayerCollection {
     public void writeExcluding(Player exclude, String message) {
         for (Player player : getPlayers()) {
             if (player != exclude) {
-                player.getChannel().write(message);
+                player.getChannel().writeAndFlush(message);
             }
         }
     }

--- a/server/src/main/java/org/moparforia/server/game/gametypes/GolfGame.java
+++ b/server/src/main/java/org/moparforia/server/game/gametypes/GolfGame.java
@@ -1,6 +1,6 @@
 package org.moparforia.server.game.gametypes;
 
-import org.jboss.netty.channel.Channel;
+import io.netty.channel.Channel;
 import org.moparforia.server.Server;
 import org.moparforia.server.game.Game;
 import org.moparforia.server.game.Lobby;
@@ -137,8 +137,8 @@ public abstract class GolfGame extends Game {
 
     public void sendGameInfo(Player player) {
         Channel c = player.getChannel();
-        c.write(new Packet(PacketType.DATA, Tools.tabularize("status", "game")));
-        c.write(new Packet(PacketType.DATA, Tools.tabularize("game", "gameinfo",
+        c.writeAndFlush(new Packet(PacketType.DATA, Tools.tabularize("status", "game")));
+        c.writeAndFlush(new Packet(PacketType.DATA, Tools.tabularize("game", "gameinfo",
                 name, passworded ? "t" : "f", gameId, numPlayers, tracks.size(),
                 tracksType, maxStrokes, strokeTimeout, waterEvent, collision, trackScoring,
                 trackScoringEnd, "f")));

--- a/server/src/main/java/org/moparforia/server/game/gametypes/golf/DualGame.java
+++ b/server/src/main/java/org/moparforia/server/game/gametypes/golf/DualGame.java
@@ -26,7 +26,7 @@ public class DualGame extends GolfGame {
                 false, numberOfTracks, -1, tracksType,
                 maxStrokes, strokeTimeout, waterEvent, collision,
                 trackScoring, trackScoringEnd, 2);
-        challenged.getChannel().write(new Packet(PacketType.DATA,
+        challenged.getChannel().writeAndFlush(new Packet(PacketType.DATA,
                 Tools.tabularize("lobby", "challenge", challenger.getNick(), numberOfTracks,
                         tracksType, maxStrokes, strokeTimeout, waterEvent,
                         collision, trackScoring, trackScoringEnd)));

--- a/server/src/main/java/org/moparforia/server/net/ClientState.java
+++ b/server/src/main/java/org/moparforia/server/net/ClientState.java
@@ -1,22 +1,44 @@
 package org.moparforia.server.net;
 
-import org.jboss.netty.channel.Channel;
-import org.jboss.netty.channel.ChannelLocal;
+
+import io.netty.util.AttributeKey;
+
 
 public final class ClientState {
 
-    public static final ChannelLocal<Long> sentCount = new ChannelLocal<Long>() {
-        @Override
-        protected Long initialValue(Channel channel) {
-            return 0L;
-        }
-    };
+    public static final AttributeKey<ClientState> CLIENT_STATE_ATTRIBUTE_KEY = AttributeKey.valueOf("MESSAGE_COUNTS");
 
-    public static final ChannelLocal<Long> recvCount = new ChannelLocal<Long>() {
-        @Override
-        protected Long initialValue(Channel channel) {
-            return 0L;
-        }
-    };
+    private long sentCount;
+    private long receivedCount;
+    private long lastActivityTime;
 
+    public ClientState() {
+        this.sentCount = 0;
+        this.receivedCount = 0;
+        this.lastActivityTime = System.currentTimeMillis();
+    }
+
+    public long getSentCount() {
+        return sentCount;
+    }
+
+    public void setSentCount(long sentCount) {
+        this.sentCount = sentCount;
+    }
+
+    public long getReceivedCount() {
+        return receivedCount;
+    }
+
+    public void setReceivedCount(long receivedCount) {
+        this.receivedCount = receivedCount;
+    }
+
+    public long getLastActivityTime() {
+        return lastActivityTime;
+    }
+
+    public void setLastActivityTime(long lastActivityTime) {
+        this.lastActivityTime = lastActivityTime;
+    }
 }

--- a/server/src/main/java/org/moparforia/server/net/Packet.java
+++ b/server/src/main/java/org/moparforia/server/net/Packet.java
@@ -1,6 +1,6 @@
 package org.moparforia.server.net;
 
-import org.jboss.netty.channel.Channel;
+import io.netty.channel.Channel;
 
 @SuppressWarnings("SameParameterValue")
 public class Packet {

--- a/server/src/main/java/org/moparforia/server/net/PacketDecoder.java
+++ b/server/src/main/java/org/moparforia/server/net/PacketDecoder.java
@@ -1,27 +1,26 @@
 package org.moparforia.server.net;
 
-import org.jboss.netty.buffer.ChannelBuffer;
-import org.jboss.netty.channel.Channel;
-import org.jboss.netty.channel.ChannelHandlerContext;
-import org.jboss.netty.handler.codec.oneone.OneToOneDecoder;
-import org.jboss.netty.util.CharsetUtil;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.ByteToMessageDecoder;
+import io.netty.util.CharsetUtil;
 
-public class PacketDecoder extends OneToOneDecoder {
+import java.util.List;
+
+public class PacketDecoder extends ByteToMessageDecoder {
     @Override
-    protected Object decode(ChannelHandlerContext ctx, Channel channel, Object msg) throws Exception {
-        if (msg instanceof ChannelBuffer) {
-            Packet packet = new Packet(channel, ((ChannelBuffer) msg).toString(CharsetUtil.UTF_8));
-            if (packet.getType() == PacketType.DATA) {
-                long count = ClientState.recvCount.get(channel);
-                if (count == packet.getCount()) {
-                    ClientState.recvCount.set(channel, count + 1);
-                } else {
-                    channel.close();
-                    return null;
-                }
+    protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
+        Channel channel = ctx.channel();
+        Packet packet = new Packet(channel, in.readBytes(in.readableBytes()).toString(CharsetUtil.UTF_8));
+        if (packet.getType() == PacketType.DATA) {
+            long count = channel.attr(ClientState.CLIENT_STATE_ATTRIBUTE_KEY).get().getReceivedCount();
+            if (count == packet.getCount()) {
+                channel.attr(ClientState.CLIENT_STATE_ATTRIBUTE_KEY).get().setReceivedCount(count + 1);
+            } else {
+                channel.close();
             }
-            return packet;
         }
-        return msg;
+        out.add(packet);
     }
 }

--- a/server/src/main/java/org/moparforia/server/net/packethandlers/NewHandler.java
+++ b/server/src/main/java/org/moparforia/server/net/packethandlers/NewHandler.java
@@ -1,6 +1,6 @@
 package org.moparforia.server.net.packethandlers;
 
-import org.jboss.netty.channel.Channel;
+import io.netty.channel.Channel;
 import org.moparforia.server.Server;
 import org.moparforia.server.event.PlayerConnectedEvent;
 import org.moparforia.server.game.Player;
@@ -28,9 +28,9 @@ public class NewHandler implements PacketHandler {
         Channel channel = packet.getChannel();
         int id = server.getNextPlayerId();
         Player player = new Player(channel, id);
-        channel.setAttachment(player);
+        channel.attr(Player.PLAYER_ATTRIBUTE_KEY).set(player);
         server.addPlayer(player);
-        channel.write("c id " + id + "\n");
+        channel.writeAndFlush("c id " + id + "\n");
         server.addEvent(new PlayerConnectedEvent(player.getId(), false));
         return true;
     }

--- a/server/src/main/java/org/moparforia/server/net/packethandlers/QuitHandler.java
+++ b/server/src/main/java/org/moparforia/server/net/packethandlers/QuitHandler.java
@@ -26,7 +26,7 @@ public class QuitHandler implements PacketHandler {
 
     @Override
     public boolean handle(Server server, Packet packet, Matcher message) {
-        Player player = (Player) packet.getChannel().getAttachment();
+        Player player = packet.getChannel().attr(Player.PLAYER_ATTRIBUTE_KEY).get();
         if (message.group(1).contains("lobby")) {
             player.getLobby().removePlayer(player, Lobby.PART_REASON_USERLEFT);
         }

--- a/server/src/main/java/org/moparforia/server/net/packethandlers/ReconnectHandler.java
+++ b/server/src/main/java/org/moparforia/server/net/packethandlers/ReconnectHandler.java
@@ -1,6 +1,6 @@
 package org.moparforia.server.net.packethandlers;
 
-import org.jboss.netty.channel.Channel;
+import io.netty.channel.Channel;
 import org.moparforia.server.Server;
 import org.moparforia.server.event.PlayerConnectedEvent;
 import org.moparforia.server.game.Player;
@@ -32,8 +32,8 @@ public class ReconnectHandler implements PacketHandler {
             Player p = server.getPlayer(id);
             Channel c = packet.getChannel();
             p.setChannel(c);
-            c.setAttachment(p);
-            c.write("c rcok\n");
+            c.attr(Player.PLAYER_ATTRIBUTE_KEY).set(p);
+            c.writeAndFlush("c rcok\n");
             server.addEvent(new PlayerConnectedEvent(id, true));
         }
         return true;

--- a/server/src/main/java/org/moparforia/server/net/packethandlers/VersionHandler.java
+++ b/server/src/main/java/org/moparforia/server/net/packethandlers/VersionHandler.java
@@ -30,10 +30,10 @@ public class VersionHandler implements PacketHandler {
             packet.getChannel().close();
             return true;
         }
-        Player player = (Player) packet.getChannel().getAttachment();
+        Player player = packet.getChannel().attr(Player.PLAYER_ATTRIBUTE_KEY).get();
         player.setGameType(gameType);
         if(gameType == GameType.GOLF) {
-            player.getChannel().write(new Packet(PacketType.DATA, Tools.tabularize("status", "login")));
+            player.getChannel().writeAndFlush(new Packet(PacketType.DATA, Tools.tabularize("status", "login")));
         }//todo
         return true;
     }

--- a/server/src/main/java/org/moparforia/server/net/packethandlers/golf/ChatHandler.java
+++ b/server/src/main/java/org/moparforia/server/net/packethandlers/golf/ChatHandler.java
@@ -29,7 +29,7 @@ public class ChatHandler implements PacketHandler {
 
     @Override
     public boolean handle(Server server, Packet packet, Matcher message) {
-        Player player = (Player) packet.getChannel().getAttachment();
+        Player player = packet.getChannel().attr(Player.PLAYER_ATTRIBUTE_KEY).get();
         PlayerCollection destination;
         if (message.group(1).equals("game")) {
             destination = player.getGame();
@@ -43,10 +43,10 @@ public class ChatHandler implements PacketHandler {
             for (Player otherPlayer : destination.getPlayers()) {
                 if (player != otherPlayer) {
                     if (message.group(1).equals("game")) {
-                        otherPlayer.getChannel().write(new Packet(PacketType.DATA,
+                        otherPlayer.getChannel().writeAndFlush(new Packet(PacketType.DATA,
                                 Tools.tabularize("game", "say", ((Game) destination).getPlayerId(player), message.group(3))));
                     } else {
-                        otherPlayer.getChannel().write(new Packet(PacketType.DATA,
+                        otherPlayer.getChannel().writeAndFlush(new Packet(PacketType.DATA,
                                 Tools.tabularize("lobby", "say", message.group(3), player.getNick(), message.group(4))));
                     }
                 }
@@ -54,7 +54,7 @@ public class ChatHandler implements PacketHandler {
         } else if (message.group(2).equals("sayp")) {
             for (Player otherPlayer : destination.getPlayers()) {
                 if (otherPlayer.getNick().equals(message.group(3))) {
-                    otherPlayer.getChannel().write(new Packet(PacketType.DATA,
+                    otherPlayer.getChannel().writeAndFlush(new Packet(PacketType.DATA,
                             Tools.tabularize(message.group(1), "sayp", player.getNick(), message.group(4))));
                     break;
                 }

--- a/server/src/main/java/org/moparforia/server/net/packethandlers/golf/GameHandler.java
+++ b/server/src/main/java/org/moparforia/server/net/packethandlers/golf/GameHandler.java
@@ -28,7 +28,7 @@ public class GameHandler implements PacketHandler {
 
     @Override
     public boolean handle(Server server, Packet packet, Matcher message) {
-        Player player = (Player) packet.getChannel().getAttachment();
+        Player player = packet.getChannel().attr(Player.PLAYER_ATTRIBUTE_KEY).get();
         Game game = player.getGame();
         return game.handlePacket(server, player, message);
     }

--- a/server/src/main/java/org/moparforia/server/net/packethandlers/golf/LanguageHandler.java
+++ b/server/src/main/java/org/moparforia/server/net/packethandlers/golf/LanguageHandler.java
@@ -23,7 +23,7 @@ public class LanguageHandler implements PacketHandler {
 
     @Override
     public boolean handle(Server server, Packet packet, Matcher message) {
-        Player player = (Player) packet.getChannel().getAttachment();
+        Player player = packet.getChannel().attr(Player.PLAYER_ATTRIBUTE_KEY).get();
         player.setLocale(message.group(1)); // todo: check if we axly support this locale
         return true;
     }

--- a/server/src/main/java/org/moparforia/server/net/packethandlers/golf/LobbyCreateSinglePlayerHandler.java
+++ b/server/src/main/java/org/moparforia/server/net/packethandlers/golf/LobbyCreateSinglePlayerHandler.java
@@ -28,7 +28,7 @@ public class LobbyCreateSinglePlayerHandler implements PacketHandler {
 
     @Override
     public boolean handle(Server server, Packet packet, Matcher message) {
-        Player player = (Player) packet.getChannel().getAttachment();
+        Player player = packet.getChannel().attr(Player.PLAYER_ATTRIBUTE_KEY).get();
         int number = Integer.parseInt(message.group(2));
         if (message.group(1).equals("t")) {
             int trackType = Integer.parseInt(message.group(3));

--- a/server/src/main/java/org/moparforia/server/net/packethandlers/golf/LobbyDualplayerHandler.java
+++ b/server/src/main/java/org/moparforia/server/net/packethandlers/golf/LobbyDualplayerHandler.java
@@ -29,12 +29,12 @@ public class LobbyDualplayerHandler implements PacketHandler {
 
     @Override
     public boolean handle(Server server, Packet packet, Matcher message) {
-        Player player = (Player) packet.getChannel().getAttachment();
+        Player player = packet.getChannel().attr(Player.PLAYER_ATTRIBUTE_KEY).get();
         if (message.group(1).equals("lobby")) {
             if (message.group(2).equals("challenge")) {
                 Player other = getPlayer(server, message.group(3));
                 if (other == null) {// || other.isNotAcceptingChallenges()) {
-                    player.getChannel().write(new Packet(PacketType.DATA,
+                    player.getChannel().writeAndFlush(new Packet(PacketType.DATA,
                             Tools.tabularize("lobby", "cfail", "nochall")));
                     return true;
                 }
@@ -51,7 +51,7 @@ public class LobbyDualplayerHandler implements PacketHandler {
             } else if (message.group(2).equals("accept")) {
                 Player other = getPlayer(server, message.group(3));
                 if (other == null || !(other.getGame() instanceof DualGame)) {
-                    player.getChannel().write(new Packet(PacketType.DATA,
+                    player.getChannel().writeAndFlush(new Packet(PacketType.DATA,
                             Tools.tabularize("lobby", "cfail", "nouser")));//todo kick the faggot
                     return true;
                 }
@@ -60,20 +60,20 @@ public class LobbyDualplayerHandler implements PacketHandler {
             } else if (message.group(2).equals("cancel")) {
                 Player other = getPlayer(server, message.group(3));
                 if (other == null || !(other.getGame() instanceof DualGame)) {
-                    player.getChannel().write(new Packet(PacketType.DATA,
+                    player.getChannel().writeAndFlush(new Packet(PacketType.DATA,
                             Tools.tabularize("lobby", "cfail", "nouser")));//todo kick the faggot
                     return true;
                 }
-                other.getChannel().write(new Packet(PacketType.DATA,
+                other.getChannel().writeAndFlush(new Packet(PacketType.DATA,
                         Tools.tabularize("lobby", "cancel")));
             } else if (message.group(2).equals("cfail") && message.group(4).equals("refuse")) {
                 Player other = getPlayer(server, message.group(3));
                 if (other == null || !(other.getGame() instanceof DualGame)) {
-                    player.getChannel().write(new Packet(PacketType.DATA,//todo kick the faggot
+                    player.getChannel().writeAndFlush(new Packet(PacketType.DATA,//todo kick the faggot
                             Tools.tabularize("lobby", "cfail", "nouser")));
                     return true;
                 }
-                other.getChannel().write(new Packet(PacketType.DATA,
+                other.getChannel().writeAndFlush(new Packet(PacketType.DATA,
                         Tools.tabularize("lobby", "cfail", "refuse")));
                 //todo HOW TO REMOVE THE GAME FROM THE SERVER
             } else if (message.group(2).equals("nc")) {

--- a/server/src/main/java/org/moparforia/server/net/packethandlers/golf/LobbyHandler.java
+++ b/server/src/main/java/org/moparforia/server/net/packethandlers/golf/LobbyHandler.java
@@ -35,7 +35,7 @@ public class LobbyHandler implements PacketHandler {
 
     @Override
     public boolean handle(Server server, Packet packet, Matcher message) {
-        Player player = (Player) packet.getChannel().getAttachment();
+        Player player = packet.getChannel().attr(Player.PLAYER_ATTRIBUTE_KEY).get();
         if (message.group(1).equals("back")) {
             if (player.getLobby() == null) {
                 packet.getChannel().close();
@@ -73,7 +73,7 @@ public class LobbyHandler implements PacketHandler {
             for (int i = 0; i < tracksInfo.length; i++) {
                 cmd += Tools.tabularize(tracksInfo[i]) + (i == tracksInfo.length - 1 ? "" : '\t');
             }
-            packet.getChannel().write(new Packet(PacketType.DATA,
+            packet.getChannel().writeAndFlush(new Packet(PacketType.DATA,
                     Tools.tabularize("lobby", "tracksetlist", cmd)));
         }
         return true;

--- a/server/src/main/java/org/moparforia/server/net/packethandlers/golf/LobbyMultiplayerHandler.java
+++ b/server/src/main/java/org/moparforia/server/net/packethandlers/golf/LobbyMultiplayerHandler.java
@@ -30,7 +30,7 @@ public class LobbyMultiplayerHandler implements PacketHandler {
     }
 
     public boolean handle(Server server, Packet packet, Matcher message) {
-        Player player = (Player) packet.getChannel().getAttachment();
+        Player player = packet.getChannel().attr(Player.PLAYER_ATTRIBUTE_KEY).get();
         Lobby lobby = player.getLobby();
 
         if (message.group(1).equals("c")) {

--- a/server/src/main/java/org/moparforia/server/net/packethandlers/golf/LobbySelectHandler.java
+++ b/server/src/main/java/org/moparforia/server/net/packethandlers/golf/LobbySelectHandler.java
@@ -30,11 +30,11 @@ public class LobbySelectHandler implements PacketHandler {
     @Override
     public boolean handle(Server server, Packet packet, Matcher message) {
         if (message.group(1).equals("rnop")) {
-            packet.getChannel().write("d lobbyselect\tnop\t" + Tools.tabularize(server.getLobby(LobbyType.SINGLE).totalPlayerCount(), server.getLobby(LobbyType.DUAL).totalPlayerCount(), server.getLobby(LobbyType.MULTI).totalPlayerCount()));
+            packet.getChannel().writeAndFlush("d lobbyselect\tnop\t" + Tools.tabularize(server.getLobby(LobbyType.SINGLE).totalPlayerCount(), server.getLobby(LobbyType.DUAL).totalPlayerCount(), server.getLobby(LobbyType.MULTI).totalPlayerCount()));
         } else if (message.group(1).equals("select")) {
             // 1 for single, 1h for single hidden chat, 2 for dual, x for multi
             LobbyType lobbyType = LobbyType.getLobby(message.group(2));
-            Player player = (Player) packet.getChannel().getAttachment();
+            Player player = packet.getChannel().attr(Player.PLAYER_ATTRIBUTE_KEY).get();
             player.setChatHidden(message.group(3) != null && message.group(3).equals("h"));
             server.getLobby(lobbyType).addPlayer(player, Lobby.JOIN_TYPE_NORMAL);
         }

--- a/server/src/main/java/org/moparforia/server/net/packethandlers/golf/LoginHandler.java
+++ b/server/src/main/java/org/moparforia/server/net/packethandlers/golf/LoginHandler.java
@@ -27,7 +27,7 @@ public class LoginHandler implements PacketHandler {
 
     @Override
     public boolean handle(Server server, Packet packet, Matcher message) {
-        Player player = (Player) packet.getChannel().getAttachment();
+        Player player = packet.getChannel().attr(Player.PLAYER_ATTRIBUTE_KEY).get();
 
 
         String username = "~anonym-" + (int) (Math.random() * 10000);
@@ -36,8 +36,8 @@ public class LoginHandler implements PacketHandler {
         player.setEmailVerified(true);
         player.setRegistered(false);
 
-        packet.getChannel().write(new Packet(PacketType.DATA, Tools.tabularize("basicinfo", player.isEmailVerified(), player.getAccessLevel(), "t", "t")));
-        packet.getChannel().write(new Packet(PacketType.DATA, Tools.tabularize("status", "lobbyselect", "300")));
+        packet.getChannel().writeAndFlush(new Packet(PacketType.DATA, Tools.tabularize("basicinfo", player.isEmailVerified(), player.getAccessLevel(), "t", "t")));
+        packet.getChannel().writeAndFlush(new Packet(PacketType.DATA, Tools.tabularize("status", "lobbyselect", "300")));
         return true;
     }
 }

--- a/server/src/main/java/org/moparforia/server/net/packethandlers/golf/LoginTypeHandler.java
+++ b/server/src/main/java/org/moparforia/server/net/packethandlers/golf/LoginTypeHandler.java
@@ -26,7 +26,7 @@ public class LoginTypeHandler implements PacketHandler {
 
     @Override
     public boolean handle(Server server, Packet packet, Matcher message) {
-        packet.getChannel().write(new Packet(PacketType.DATA, Tools.tabularize("status", "login")));
+        packet.getChannel().writeAndFlush(new Packet(PacketType.DATA, Tools.tabularize("status", "login")));
         return true;
     }
 }

--- a/server/src/main/java/org/moparforia/server/net/packethandlers/golf/TrackTestLoginHandler.java
+++ b/server/src/main/java/org/moparforia/server/net/packethandlers/golf/TrackTestLoginHandler.java
@@ -50,12 +50,12 @@ public class TrackTestLoginHandler implements PacketHandler {
             }
         }
 
-        Player player = (Player) packet.getChannel().getAttachment();
+        Player player = packet.getChannel().attr(Player.PLAYER_ATTRIBUTE_KEY).get();
         player.setNick(username);
         player.setEmailVerified(true);
         player.setRegistered(!anonym);
-        packet.getChannel().write(new Packet(PacketType.DATA, Tools.tabularize("basicinfo", player.isEmailVerified(), player.getAccessLevel(), "t", "f")));
-        packet.getChannel().write(new Packet(PacketType.DATA, Tools.tabularize("status", "lobbyselect", 300)));
+        packet.getChannel().writeAndFlush(new Packet(PacketType.DATA, Tools.tabularize("basicinfo", player.isEmailVerified(), player.getAccessLevel(), "t", "f")));
+        packet.getChannel().writeAndFlush(new Packet(PacketType.DATA, Tools.tabularize("status", "lobbyselect", 300)));
         return true;
     }
 }


### PR DESCRIPTION
The final release of the Netty 3.x line was in 2016 and ever since, it has been EOL (https://netty.io/news/2016/06/29/3-10-6-Final.html). Nowadays it has multiple unpatched security issues. This patch migrates the server to the latest Netty release. 4.1.112. The 4.0 branch is skipped since it is also EOL since 2018.

There are a bunch of breaking changes between the versions:
- Channel attachments were removed in favor of attributes, so now ClientState and Player objects are stored as attributes
- `flush` needs to be called to actually send messages to clients so all calls to `write` are replaced with `writeAndFlush`. In theory this can be optimized to buffer multiple writes but since the server is not performance critical, I opted to keep it simple and always flush writes.
- All Netty imports had their package changed from org.jboss to io.netty
- ChannelBuffer was renamed to ByteBuf
- A bunch of handler methods were renamed (e.g. channelConnected -> channelActive, messageReceived -> channelRead, channelClosed -> channelInactive)
- IdleStateAwareChannelHandler was removed and now idle events are be processed by `userEventTriggered`. `getLastActivityTimeMillis` was also removed from idle events, so I reimplemented that functionality in ClientState.
- OneToOneDecoder and OneToOneEncoder were replaced with more strongly typed classes, ByteToMessageDecoder and MessageToByteEncoder. They no longer return values, instead they add to the output list passed in as a parameter.
- The ServerBootstrap API was redesigned to use a fluent API and a ChannelInitializer instead of a pipeline factory. The new API is mostly compatible with the old one though.