### PR TITLE
Fix single player quick start, add ranking icons to player lists in lobbies

### DIFF
--- a/client/src/main/java/com/aapeli/client/ImageTracker.java
+++ b/client/src/main/java/com/aapeli/client/ImageTracker.java
@@ -5,7 +5,6 @@ import com.aapeli.tools.Tools;
 
 import java.applet.Applet;
 import java.awt.Image;
-import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.Vector;
 
@@ -146,24 +145,18 @@ class ImageTracker implements Runnable {
             }
         }
 
-        Enumeration<Image> var6 = this.imageTable.elements();
-
-        while (var6.hasMoreElements()) {
+        for (Image image: this.imageTable.values()) {
             try {
-                var6.nextElement().flush();
-            } catch (Exception var5) {
-            }
+                image.flush();
+            } catch (Exception e) {}
         }
 
         this.imageTable.clear();
         this.imageTable = null;
-        Enumeration<ImageResource> var7 = this.imageResourceTable.elements();
-
-        while (var7.hasMoreElements()) {
+        for (ImageResource imageResource: this.imageResourceTable) {
             try {
-                var7.nextElement().method1652();
-            } catch (Exception var4) {
-            }
+                imageResource.method1652();
+            } catch (Exception e) {}
         }
 
         this.imageResourceTable.removeAllElements();

--- a/client/src/main/java/com/aapeli/client/InputTextField.java
+++ b/client/src/main/java/com/aapeli/client/InputTextField.java
@@ -8,7 +8,6 @@ import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
-import java.util.Enumeration;
 import java.util.Vector;
 
 public class InputTextField extends TextField implements FocusListener, KeyListener, ActionListener {
@@ -135,10 +134,8 @@ public class InputTextField extends TextField implements FocusListener, KeyListe
     public void actionPerformed(ActionEvent evt) {
         if (evt.getSource() == this) {
             synchronized (this) {
-                Enumeration<InputTextFieldListener> enumeration = this.listeners.elements();
-
-                while (enumeration.hasMoreElements()) {
-                    enumeration.nextElement().enterPressed();
+                for (InputTextFieldListener listener: this.listeners) {
+                    listener.enterPressed();
                 }
             }
         }
@@ -244,20 +241,15 @@ public class InputTextField extends TextField implements FocusListener, KeyListe
             this.setCaretPosition(lastCharIndex);
         }
 
-        Enumeration<InputTextFieldListener> enumeration;
         if (this.inputTextLength == 0 && textLen > 0) {
-            enumeration = this.listeners.elements();
-
-            while (enumeration.hasMoreElements()) {
-                enumeration.nextElement().startedTyping();
+            for (InputTextFieldListener listener: this.listeners) {
+                listener.startedTyping();
             }
         }
 
         if (this.inputTextLength > 0 && textLen == 0) {
-            enumeration = this.listeners.elements();
-
-            while (enumeration.hasMoreElements()) {
-                enumeration.nextElement().clearedField();
+            for (InputTextFieldListener listener: this.listeners) {
+                listener.clearedField();
             }
         }
 

--- a/client/src/main/java/com/aapeli/client/SoundManager.java
+++ b/client/src/main/java/com/aapeli/client/SoundManager.java
@@ -4,7 +4,6 @@ import com.aapeli.applet.AApplet;
 
 import java.applet.AudioClip;
 import java.net.URL;
-import java.util.Enumeration;
 import java.util.Hashtable;
 
 public final class SoundManager implements Runnable {
@@ -55,21 +54,14 @@ public final class SoundManager implements Runnable {
         boolean anySoundClipsNotDefined;
         do {
             anySoundClipsNotDefined = false;
-            Enumeration<SoundClip> soundClips = this.clientSounds.elements();
-
-            SoundClip soundClip;
-            while (soundClips.hasMoreElements()) {
-                soundClip = soundClips.nextElement();
+            for (SoundClip soundClip: this.clientSounds.values()) {
                 if (!soundClip.isDefined()) {
                     soundClip.defineClip();
                     anySoundClipsNotDefined = true;
                 }
             }
 
-            soundClips = this.sharedSounds.elements();
-
-            while (soundClips.hasMoreElements()) {
-                soundClip = soundClips.nextElement();
+            for (SoundClip soundClip: this.sharedSounds.values()) {
                 if (!soundClip.isDefined()) {
                     soundClip.defineClip();
                     anySoundClipsNotDefined = true;

--- a/client/src/main/java/com/aapeli/colorgui/Choicer.java
+++ b/client/src/main/java/com/aapeli/colorgui/Choicer.java
@@ -10,7 +10,6 @@ import java.awt.event.ComponentEvent;
 import java.awt.event.ComponentListener;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
-import java.util.Enumeration;
 import java.util.Vector;
 
 public class Choicer extends IPanel implements ComponentListener, ItemListener, ItemSelectable {
@@ -60,10 +59,8 @@ public class Choicer extends IPanel implements ComponentListener, ItemListener, 
         synchronized (this.listeners) {
             if (!this.listeners.isEmpty()) {
                 e = new ItemEvent(this, e.getID(), e.getItem(), e.getStateChange());
-                Enumeration<ItemListener> listenerEnumeration = this.listeners.elements();
-
-                while (listenerEnumeration.hasMoreElements()) {
-                    listenerEnumeration.nextElement().itemStateChanged(e);
+                for (ItemListener listener: this.listeners) {
+                    listener.itemStateChanged(e);
                 }
             }
         }

--- a/client/src/main/java/com/aapeli/colorgui/ColorButton.java
+++ b/client/src/main/java/com/aapeli/colorgui/ColorButton.java
@@ -12,7 +12,6 @@ import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
-import java.util.Enumeration;
 import java.util.Vector;
 
 public class ColorButton extends IPanel implements MouseMotionListener, MouseListener {
@@ -401,12 +400,9 @@ public class ColorButton extends IPanel implements MouseMotionListener, MouseLis
         synchronized (this.aVector3280) {
             if (this.aVector3280.size() != 0) {
                 ActionEvent var2 = new ActionEvent(this, 1001, this.aString3272);
-                Enumeration<ActionListener> var3 = this.aVector3280.elements();
-
-                while (var3.hasMoreElements()) {
-                    var3.nextElement().actionPerformed(var2);
+                for (ActionListener listener : aVector3280) {
+                    listener.actionPerformed(var2);
                 }
-
             }
         }
     }

--- a/client/src/main/java/com/aapeli/colorgui/ColorCheckbox.java
+++ b/client/src/main/java/com/aapeli/colorgui/ColorCheckbox.java
@@ -12,7 +12,6 @@ import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
-import java.util.Enumeration;
 import java.util.Vector;
 
 public class ColorCheckbox extends IPanel implements ItemSelectable, MouseListener {
@@ -329,12 +328,9 @@ public class ColorCheckbox extends IPanel implements ItemSelectable, MouseListen
         synchronized (this.aVector3305) {
             if (this.aVector3305.size() != 0) {
                 ItemEvent var2 = new ItemEvent(this, 0, this, 701);
-                Enumeration<ItemListener> var3 = this.aVector3305.elements();
-
-                while (var3.hasMoreElements()) {
-                    var3.nextElement().itemStateChanged(var2);
+                for (ItemListener listener : aVector3305) {
+                    listener.itemStateChanged(var2);
                 }
-
             }
         }
     }

--- a/client/src/main/java/com/aapeli/colorgui/ColorCheckboxGroup.java
+++ b/client/src/main/java/com/aapeli/colorgui/ColorCheckboxGroup.java
@@ -1,6 +1,5 @@
 package com.aapeli.colorgui;
 
-import java.util.Enumeration;
 import java.util.Vector;
 
 public final class ColorCheckboxGroup {
@@ -22,11 +21,8 @@ public final class ColorCheckboxGroup {
     }
 
     private void method1749() {
-        Enumeration<ColorCheckbox> var1 = this.aVector1553.elements();
-
-        while (var1.hasMoreElements()) {
-            var1.nextElement().realSetState(false);
+        for (ColorCheckbox colorCheckbox : aVector1553) {
+            colorCheckbox.realSetState(false);
         }
-
     }
 }

--- a/client/src/main/java/com/aapeli/colorgui/ColorList.java
+++ b/client/src/main/java/com/aapeli/colorgui/ColorList.java
@@ -16,7 +16,6 @@ import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
-import java.util.Enumeration;
 import java.util.Vector;
 
 public final class ColorList extends Panel implements ComponentListener, AdjustmentListener, MouseListener, ItemSelectable {
@@ -189,11 +188,9 @@ public final class ColorList extends Panel implements ComponentListener, Adjustm
 
     private boolean method944() {
         ColorListItemGroup var1 = null;
-        Enumeration<ColorListItem> var4 = this.aVector669.elements();
 
-        while (var4.hasMoreElements()) {
-            ColorListItem var3 = var4.nextElement();
-            ColorListItemGroup var2 = var3.getGroup();
+        for (ColorListItem colorListItem: this.aVector669) {
+            ColorListItemGroup var2 = colorListItem.getGroup();
             if (var2 != null) {
                 if (var1 != null && var2 != var1) {
                     return true;
@@ -665,12 +662,9 @@ public final class ColorList extends Panel implements ComponentListener, Adjustm
     private synchronized void method954(ColorListItem var1, int var2, int var3) {
         if (this.aVector680.size() != 0) {
             ItemEvent var4 = new ItemEvent(this, var2, var1, var3);
-            Enumeration<ItemListener> var5 = this.aVector680.elements();
-
-            while (var5.hasMoreElements()) {
-                var5.nextElement().itemStateChanged(var4);
+            for (ItemListener itemListener: this.aVector680) {
+                itemListener.itemStateChanged(var4);
             }
-
         }
     }
 

--- a/client/src/main/java/com/aapeli/colorgui/ColorSpinner.java
+++ b/client/src/main/java/com/aapeli/colorgui/ColorSpinner.java
@@ -14,7 +14,6 @@ import java.awt.event.ItemListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
-import java.util.Enumeration;
 import java.util.Vector;
 
 public final class ColorSpinner extends IPanel implements MouseListener, MouseMotionListener, ItemSelectable {
@@ -402,12 +401,9 @@ public final class ColorSpinner extends IPanel implements MouseListener, MouseMo
         String var1 = this.getSelectedItem();
         if (var1 != null) {
             ItemEvent var2 = new ItemEvent(this, 701, var1, ItemEvent.SELECTED);
-            Enumeration<ItemListener> var3 = this.aVector3318.elements();
-
-            while (var3.hasMoreElements()) {
-                var3.nextElement().itemStateChanged(var2);
+            for (ItemListener listener : aVector3318) {
+                listener.itemStateChanged(var2);
             }
-
         }
     }
 

--- a/client/src/main/java/com/aapeli/colorgui/MultiColorList.java
+++ b/client/src/main/java/com/aapeli/colorgui/MultiColorList.java
@@ -16,7 +16,6 @@ import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
-import java.util.Enumeration;
 import java.util.Vector;
 
 public class MultiColorList extends Panel implements AdjustmentListener, MouseListener, ItemSelectable {
@@ -714,12 +713,9 @@ public class MultiColorList extends Panel implements AdjustmentListener, MouseLi
     private synchronized void method962(MultiColorListItem var1, int var2, int var3) {
         if (this.aVector713.size() != 0) {
             ItemEvent var4 = new ItemEvent(this, var2, var1, var3);
-            Enumeration<ItemListener> var5 = this.aVector713.elements();
-
-            while (var5.hasMoreElements()) {
-                var5.nextElement().itemStateChanged(var4);
+            for (ItemListener listener: this.aVector713) {
+                listener.itemStateChanged(var4);
             }
-
         }
     }
 

--- a/client/src/main/java/com/aapeli/colorgui/RadioButtonGroup.java
+++ b/client/src/main/java/com/aapeli/colorgui/RadioButtonGroup.java
@@ -2,7 +2,6 @@ package com.aapeli.colorgui;
 
 import com.aapeli.client.IPanel;
 
-import java.util.Enumeration;
 import java.util.Vector;
 
 public final class RadioButtonGroup {
@@ -38,16 +37,12 @@ public final class RadioButtonGroup {
     }
 
     private void method1759() {
-        Enumeration<IPanel> var1 = this.aVector1589.elements();
-
-        while (var1.hasMoreElements()) {
-            Object var2 = var1.nextElement();
+        for (IPanel var2: this.aVector1589) {
             if (var2 instanceof RadioButton) {
                 ((RadioButton) var2).realSetState(false);
             } else {
                 ((RoundRadioButton) var2).realSetState(false);
             }
         }
-
     }
 }

--- a/client/src/main/java/com/aapeli/colorgui/RoundButton.java
+++ b/client/src/main/java/com/aapeli/colorgui/RoundButton.java
@@ -12,7 +12,6 @@ import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
-import java.util.Enumeration;
 import java.util.Vector;
 
 public class RoundButton extends IPanel implements MouseMotionListener, MouseListener {
@@ -263,12 +262,9 @@ public class RoundButton extends IPanel implements MouseMotionListener, MouseLis
         synchronized (this.aVector3395) {
             if (this.aVector3395.size() != 0) {
                 ActionEvent var2 = new ActionEvent(this, 1001, this.aString3387);
-                Enumeration<ActionListener> var3 = this.aVector3395.elements();
-
-                while (var3.hasMoreElements()) {
-                    var3.nextElement().actionPerformed(var2);
+                for (ActionListener listener : aVector3395) {
+                    listener.actionPerformed(var2);
                 }
-
             }
         }
     }

--- a/client/src/main/java/com/aapeli/colorgui/TabBar.java
+++ b/client/src/main/java/com/aapeli/colorgui/TabBar.java
@@ -12,7 +12,6 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.ComponentEvent;
 import java.awt.event.ComponentListener;
-import java.util.Enumeration;
 import java.util.Vector;
 
 public class TabBar extends IPanel implements ComponentListener, ActionListener {
@@ -382,12 +381,9 @@ public class TabBar extends IPanel implements ComponentListener, ActionListener 
         Object var2 = this.anObject3425;
         synchronized (this.anObject3425) {
             if (this.aVector3424.size() != 0) {
-                Enumeration<TabBarListener> var3 = this.aVector3424.elements();
-
-                while (var3.hasMoreElements()) {
-                    var3.nextElement().selectedTabChanged(var1);
+                for (TabBarListener tabBarListener : aVector3424) {
+                    tabBarListener.selectedTabChanged(var1);
                 }
-
             }
         }
     }

--- a/client/src/main/java/com/aapeli/tools/QuickTimer.java
+++ b/client/src/main/java/com/aapeli/tools/QuickTimer.java
@@ -1,7 +1,5 @@
 package com.aapeli.tools;
 
-import java.util.Enumeration;
-import java.util.NoSuchElementException;
 import java.util.Vector;
 
 public class QuickTimer implements Runnable {
@@ -41,16 +39,7 @@ public class QuickTimer implements Runnable {
     public void run() {
         Tools.sleep(this.anInt1727);
         if (!this.stopped) {
-            Enumeration<QuickTimerListener> var1 = this.aVector1728.elements();
-
-            while (var1.hasMoreElements()) {
-                QuickTimerListener var2;
-                try {
-                    var2 = var1.nextElement();
-                } catch (NoSuchElementException var4) {
-                    return;
-                }
-
+            for (QuickTimerListener var2: this.aVector1728) {
                 if (var2 != null) {
                     var2.qtFinished();
                 }

--- a/server/src/main/java/org/moparforia/server/game/Player.java
+++ b/server/src/main/java/org/moparforia/server/game/Player.java
@@ -20,7 +20,7 @@ public class Player {
     private String avatarUrl;
     private String clan;
     private int accessLevel;
-    private int points;
+    private int ranking;
     private boolean emailVerified;// todo or something like that maybe, find out
     private boolean registered;
     private boolean vip;
@@ -36,7 +36,7 @@ public class Player {
     public Player(Channel channel, int id) {
         this.channel = channel;
         this.id = id;
-        points = 0;
+        ranking = 0;
         resetVals();
     }
 
@@ -52,7 +52,7 @@ public class Player {
         avatarUrl = "-";
         clan = "-";
         accessLevel = ACCESSLEVEL_NORMAL;
-        points = 10000;
+        ranking = 0;
         emailVerified = false;
         registered = false;
         vip = false;
@@ -132,12 +132,12 @@ public class Player {
         this.accessLevel = whatsyourgame;
     }
 
-    public int getPoints() {
-        return points;
+    public int getRanking() {
+        return ranking;
     }
 
-    public void setPoints(int points) {
-        this.points = points;
+    public void setRanking(int ranking) {
+        this.ranking = ranking;
     }
 
     public boolean isEmailVerified() {
@@ -216,7 +216,7 @@ public class Player {
         if (o == null || !(o instanceof Player))
             return false;
         Player p = (Player) o;
-        return nick.equals(p.nick) && points == p.points && locale.equals(p.locale);
+        return nick.equals(p.nick) && ranking == p.ranking && locale.equals(p.locale);
     }
 
     public String toString() {
@@ -224,7 +224,7 @@ public class Player {
         return Tools.triangelize(
                 "3:" + (nick != null ? nick : ""),
                 tmp.equals("") ? "w" : tmp,
-                points,
+                ranking,
                 locale != null ? locale : "",
                 profileUrl != null ? profileUrl : "",
                 avatarUrl != null ? avatarUrl : ""

--- a/server/src/main/java/org/moparforia/server/net/packethandlers/golf/LobbyCreateSinglePlayerHandler.java
+++ b/server/src/main/java/org/moparforia/server/net/packethandlers/golf/LobbyCreateSinglePlayerHandler.java
@@ -1,6 +1,8 @@
 package org.moparforia.server.net.packethandlers.golf;
 
 import org.moparforia.server.Server;
+import org.moparforia.server.game.Lobby;
+import org.moparforia.server.game.LobbyType;
 import org.moparforia.server.game.Player;
 import org.moparforia.server.game.gametypes.golf.ChampionshipGame;
 import org.moparforia.server.game.gametypes.golf.TrainingGame;
@@ -19,19 +21,22 @@ public class LobbyCreateSinglePlayerHandler implements PacketHandler {
 
     @Override
     public Pattern getPattern() {
-        return Pattern.compile("lobby\\tcsp(t|c)\\t(\\d+)(?:\\t(\\d+)\\t(\\d+))?");
+        return Pattern.compile("(lobby|lobbyselect)\\tcsp(t|c)\\t(\\d+)(?:\\t(\\d+)\\t(\\d+))?");
     }                 //CLIENT> WRITE "d 5 lobby	cspt	10	7	0"
 
     @Override
     public boolean handle(Server server, Packet packet, Matcher message) {
         Player player = packet.getChannel().attr(Player.PLAYER_ATTRIBUTE_KEY).get();
-        int number = Integer.parseInt(message.group(2));
-        if (message.group(1).equals("t")) {
-            int trackType = Integer.parseInt(message.group(3));
-            int water = Integer.parseInt(message.group(4));
+        int number = Integer.parseInt(message.group(3));
+        if (message.group(2).equals("t")) { // training
+            int trackType = Integer.parseInt(message.group(4));
+            int water = Integer.parseInt(message.group(5));
+            if (message.group(1).equals("lobbyselect")) {
+                server.getLobby(LobbyType.SINGLE).addPlayer(player, Lobby.JOIN_TYPE_NORMAL);
+            }
             new TrainingGame(player, server.getNextGameId(), trackType, number, water);
 
-        } else if (message.group(1).equals("c")) {
+        } else if (message.group(2).equals("c")) { // championship
             new ChampionshipGame(player, server.getNextGameId(), number);
         } else {
             return false;

--- a/server/src/main/java/org/moparforia/server/net/packethandlers/golf/TrackTestLoginHandler.java
+++ b/server/src/main/java/org/moparforia/server/net/packethandlers/golf/TrackTestLoginHandler.java
@@ -49,7 +49,7 @@ public class TrackTestLoginHandler implements PacketHandler {
         Player player = packet.getChannel().attr(Player.PLAYER_ATTRIBUTE_KEY).get();
         player.setNick(username);
         player.setEmailVerified(true);
-        player.setRegistered(!anonym);
+        player.setRegistered(true);
         packet.getChannel().writeAndFlush(new Packet(PacketType.DATA, Tools.tabularize("basicinfo", player.isEmailVerified(), player.getAccessLevel(), "t", "f")));
         packet.getChannel().writeAndFlush(new Packet(PacketType.DATA, Tools.tabularize("status", "lobbyselect", 300)));
         return true;

--- a/server/src/test/java/org/moparforia/server/ServerTest.java
+++ b/server/src/test/java/org/moparforia/server/ServerTest.java
@@ -77,7 +77,7 @@ public class ServerTest {
         String lobbyOwnjoin = reader.readLine();
         assertEquals("d 4 status\tlobby\t1", statusLobby);
         assertEquals("d 5 lobby\tusers", lobbyUsers);
-        assertEquals("d 6 lobby\townjoin\t3:" + nickname + "^w^10000^-^-^-", lobbyOwnjoin);
+        assertEquals("d 6 lobby\townjoin\t3:" + nickname + "^r^0^-^-^-", lobbyOwnjoin);
         this.sendMessage(writer, "d 4 lobby\ttracksetlist");
         String tracksetlist = reader.readLine();
         assertEquals(tracksetlist, "d 7 lobby\ttracksetlist\tBirchwood\t1\t9\tNo one\t1\tNo one\t1\tNo one\t1\tNo one\t1\tOak Park\t1\t18\tNo one\t1\tNo one\t1\tNo one\t1\tNo one\t1\tOne by One\t2\t18\tNo one\t1\tNo one\t1\tNo one\t1\tNo one\t1\tScary Set\t3\t9\tNo one\t1\tNo one\t1\tNo one\t1\tNo one\t1\tSpruce Corpse\t2\t9\tNo one\t1\tNo one\t1\tNo one\t1\tNo one\t1\tThe First\t2\t18\tNo one\t1\tNo one\t1\tNo one\t1\tNo one\t1\tTorment Fields\t3\t18\tNo one\t1\tNo one\t1\tNo one\t1\tNo one\t1");
@@ -108,7 +108,7 @@ public class ServerTest {
         lobbyOwnjoin = reader.readLine();
         assertEquals("d 16 status\tlobby\t1", statusLobby);
         assertEquals("d 17 lobby\tusers", lobbyUsers);
-        assertEquals("d 18 lobby\townjoin\t3:" + nickname + "^w^10000^-^-^-", lobbyOwnjoin);
+        assertEquals("d 18 lobby\townjoin\t3:" + nickname + "^r^0^-^-^-", lobbyOwnjoin);
 
         // quit game
         this.sendMessage(writer, "d 7 lobby\tquit");


### PR DESCRIPTION
This PR contains the following changes:

- Use of the `Enumeration` class is removed. It is superseded by the more modern approach of using for-each loops which are more concise to read and don't pollute variable scopes.
- Single player quick start now works

| Before | After |
| ------ | ----- |
| <video src="https://github.com/user-attachments/assets/f2e23f5d-8171-42c5-a64b-4ac602b758c8"> | <video src="https://github.com/user-attachments/assets/7551b1e8-9520-4b73-9b9f-b9efcae17327"> |

- The server no longer has a busy-wait main loop, instead using a BlockingQueue, with which it can simply wait until it receives any events and then react accordingly. This saves resources and simplifies the server logic.
- Players now have ranking icon next to their names in lobbies. This was done by creating each player as registered when they sign in. I also adjusted the default ranking for players to be more sensible at 0 instead of 10000. See the little green plus next to the player name in the below picture.

| Before | After |
| ------ | ----- |
| ![lobby-rankings-old](https://github.com/user-attachments/assets/208b1af5-4ac9-4e22-8e9f-bfe2b81d18fa) | ![lobby-rankings-new](https://github.com/user-attachments/assets/0f965e24-3d6d-4143-b3ab-07c79a2f5dff) |


