### PR TITLE
Client: Use ArrayLists instead of Vectors

### DIFF
--- a/client/src/main/java/agolf/game/GameCanvas.java
+++ b/client/src/main/java/agolf/game/GameCanvas.java
@@ -17,9 +17,10 @@ import java.awt.event.KeyListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.StringTokenizer;
-import java.util.Vector;
 
 public class GameCanvas extends GameBackgroundCanvas implements Runnable, MouseMotionListener, MouseListener, KeyListener {
 
@@ -48,8 +49,8 @@ public class GameCanvas extends GameBackgroundCanvas implements Runnable, MouseM
     private double somethingSpeedThing;
     private double[] resetPositionX;
     private double[] resetPositionY;
-    private Vector<double[]>[] teleportStarts;
-    private Vector<double[]>[] teleportExists;
+    private List<double[]>[] teleportStarts;
+    private List<double[]>[] teleportExists;
     private short[][][] magnetMap;
     private double[] playerX;
     private double[] playerY;
@@ -704,17 +705,17 @@ public class GameCanvas extends GameBackgroundCanvas implements Runnable, MouseM
             }
         }
 
-        Vector<double[]> startPositions = new Vector<>();
+        List<double[]> startPositions = new ArrayList<>();
         this.resetPositionX = new double[4];
         this.resetPositionY = new double[4];
-        this.teleportExists = new Vector[4];
-        this.teleportStarts = new Vector[4];
-        Vector<int[]> magnetVec = new Vector<>();
+        this.teleportExists = new ArrayList[4];
+        this.teleportStarts = new ArrayList[4];
+        List<int[]> magnets = new ArrayList<>();
 
         for (int i = 0; i < 4; ++i) {
             this.resetPositionX[i] = this.resetPositionY[i] = -1.0D;
-            this.teleportExists[i] = new Vector<>();
-            this.teleportStarts[i] = new Vector<>();
+            this.teleportExists[i] = new ArrayList<>();
+            this.teleportStarts[i] = new ArrayList<>();
         }
 
         // Iterates over the 49*25 map
@@ -727,7 +728,7 @@ public class GameCanvas extends GameBackgroundCanvas implements Runnable, MouseM
                     //24 Start Position Common
                     if (tile == 24) {
                         double[] startPosition = new double[]{screenX, screenY};
-                        startPositions.addElement(startPosition);
+                        startPositions.add(startPosition);
                     }
                     //48 Start Position Blue
                     //49 Start Position Red
@@ -746,7 +747,7 @@ public class GameCanvas extends GameBackgroundCanvas implements Runnable, MouseM
                     if (tile == 33 || tile == 35 || tile == 37 || tile == 39) {
                         teleportIndex = (tile - 33) / 2;
                         double[] teleporter = new double[]{screenX, screenY};
-                        this.teleportExists[teleportIndex].addElement(teleporter);
+                        this.teleportExists[teleportIndex].add(teleporter);
                     }
 
                     //33 Teleport Start Blue
@@ -756,14 +757,14 @@ public class GameCanvas extends GameBackgroundCanvas implements Runnable, MouseM
                     if (tile == 32 || tile == 34 || tile == 36 || tile == 38) {
                         teleportIndex = (tile - 32) / 2;
                         double[] teleporter = new double[]{screenX, screenY};
-                        this.teleportStarts[teleportIndex].addElement(teleporter);
+                        this.teleportStarts[teleportIndex].add(teleporter);
                     }
 
                     //44 magnet attract
                     //45 magnet repel
                     if (tile == 44 || tile == 45) {
                         int[] magnet = new int[]{(int) (screenX + 0.5D), (int) (screenY + 0.5D), tile};
-                        magnetVec.addElement(magnet);
+                        magnets.add(magnet);
                     }
                 }
             }
@@ -773,12 +774,12 @@ public class GameCanvas extends GameBackgroundCanvas implements Runnable, MouseM
         if (startPositionsCount == 0) {
             this.startPositionX = this.startPositionY = -1.0D;
         } else {
-            double[] startPosition = startPositions.elementAt(gameId % startPositionsCount);
+            double[] startPosition = startPositions.get(gameId % startPositionsCount);
             this.startPositionX = startPosition[0];
             this.startPositionY = startPosition[1];
         }
 
-        int magnetVecLen = magnetVec.size();
+        int magnetVecLen = magnets.size();
         if (magnetVecLen == 0) {
             this.magnetMap = null;
         } else {
@@ -792,7 +793,7 @@ public class GameCanvas extends GameBackgroundCanvas implements Runnable, MouseM
 
                     for (int magnetIndex = 0; magnetIndex < magnetVecLen; ++magnetIndex) {
                         // [ x, y, blockid ]
-                        int[] magnet = magnetVec.elementAt(magnetIndex);
+                        int[] magnet = magnets.get(magnetIndex);
                         double forceTemp2X = magnet[0] - magnetLoopX;
                         double forcetemp2Y = magnet[1] - magnetLoopY;
                         double force = Math.sqrt(forceTemp2X * forceTemp2X + forcetemp2Y * forcetemp2Y);
@@ -1401,7 +1402,7 @@ public class GameCanvas extends GameBackgroundCanvas implements Runnable, MouseM
                 do {
                     i = startLen - 1;
                     random = this.rngSeed.next() % (i + 1);
-                    teleportPos = this.teleportStarts[teleportId].elementAt(random);
+                    teleportPos = this.teleportStarts[teleportId].get(random);
                     if (Math.abs(teleportPos[0] - (double) x) >= 15.0D || Math.abs(teleportPos[1] - (double) y) >= 15.0D) {
                         this.playerX[playerId] = teleportPos[0];
                         this.playerY[playerId] = teleportPos[1];
@@ -1436,7 +1437,7 @@ public class GameCanvas extends GameBackgroundCanvas implements Runnable, MouseM
         }
 
         //finally move player to exit position
-        teleportPos = this.teleportExists[var13].elementAt(random);
+        teleportPos = this.teleportExists[var13].get(random);
         this.playerX[playerId] = teleportPos[0];
         this.playerY[playerId] = teleportPos[1];
     }

--- a/client/src/main/java/agolf/game/HackedShot.java
+++ b/client/src/main/java/agolf/game/HackedShot.java
@@ -5,7 +5,7 @@ import agolf.SynchronizedBool;
 import com.aapeli.tools.Tools;
 
 import java.util.Arrays;
-import java.util.Vector;
+import java.util.List;
 
 /**
  * mmmkay children.
@@ -28,8 +28,8 @@ public class HackedShot implements Runnable {
     private double aDouble2820;
     private double[] aDoubleArray2821;
     private double[] aDoubleArray2822;
-    private Vector<double[]>[] aVectorArray2823;
-    private Vector<double[]>[] aVectorArray2824;
+    private List<double[]>[] teleportStarts;
+    private List<double[]>[] teleportExits;
     private short[][][] aShortArrayArrayArray2825;
     private double[] playerX;
     private double[] playerY;
@@ -60,8 +60,8 @@ public class HackedShot implements Runnable {
                       double aDouble2820,
                       double[] aDoubleArray2821,
                       double[] aDoubleArray2822,
-                      Vector<double[]>[] aVectorArray2823,
-                      Vector<double[]>[] aVectorArray2824,
+                      List<double[]>[] teleportStarts,
+                      List<double[]>[] teleportExits,
                       short[][][] aShortArrayArrayArray2825,
                       double[] playerX,
                       double[] playerY,
@@ -88,8 +88,8 @@ public class HackedShot implements Runnable {
         this.aDouble2820 = aDouble2820;
         this.aDoubleArray2821 = Arrays.copyOf(aDoubleArray2821, aDoubleArray2821.length);
         this.aDoubleArray2822 = Arrays.copyOf(aDoubleArray2822, aDoubleArray2822.length);
-        this.aVectorArray2823 = Arrays.copyOf(aVectorArray2823, aVectorArray2823.length);
-        this.aVectorArray2824 = Arrays.copyOf(aVectorArray2824, aVectorArray2824.length);
+        this.teleportStarts = Arrays.copyOf(teleportStarts, teleportStarts.length);
+        this.teleportExits = Arrays.copyOf(teleportExits, teleportExits.length);
         if (aShortArrayArrayArray2825 != null) {
             this.aShortArrayArrayArray2825 = Arrays.copyOf(aShortArrayArrayArray2825, aShortArrayArrayArray2825.length);
         } else {
@@ -497,7 +497,7 @@ public class HackedShot implements Runnable {
 
     private void method154(int var1, int var2, int var3, int var4) {
         boolean var5 = true;
-        int var6 = this.aVectorArray2824[var1].size();
+        int var6 = this.teleportExits[var1].size();
         int var7;
         int var8;
         double[] var11;
@@ -507,7 +507,7 @@ public class HackedShot implements Runnable {
             var7 = var6 - 1;
             var8 = this.aSeed_2836.next() % (var7 + 1);
         } else {
-            var7 = this.aVectorArray2823[var1].size();
+            var7 = this.teleportStarts[var1].size();
             int var10;
             if (var7 >= 2) {
                 int var14 = 0;
@@ -515,7 +515,7 @@ public class HackedShot implements Runnable {
                 do {
                     var10 = var7 - 1;
                     var8 = this.aSeed_2836.next() % (var10 + 1);
-                    var11 = this.aVectorArray2823[var1].elementAt(var8);
+                    var11 = this.teleportStarts[var1].get(var8);
                     if (Math.abs(var11[0] - (double) var3) >= 15.0D || Math.abs(var11[1] - (double) var4) >= 15.0D) {
                         this.playerX[var2] = var11[0];
                         this.playerY[var2] = var11[1];
@@ -531,7 +531,7 @@ public class HackedShot implements Runnable {
             boolean var9 = false;
 
             for (var10 = 0; var10 < 4 && !var9; ++var10) {
-                if (this.aVectorArray2824[var10].size() > 0) {
+                if (this.teleportExits[var10].size() > 0) {
                     var9 = true;
                 }
             }
@@ -542,14 +542,14 @@ public class HackedShot implements Runnable {
 
             do {
                 var13 = this.aSeed_2836.next() % 4;
-                var6 = this.aVectorArray2824[var13].size();
+                var6 = this.teleportExits[var13].size();
             } while (var6 == 0);
 
             int var12 = var6 - 1;
             var8 = this.aSeed_2836.next() % (var12 + 1);
         }
 
-        var11 = this.aVectorArray2824[var13].elementAt(var8);
+        var11 = this.teleportExits[var13].get(var8);
         this.playerX[var2] = var11[0];
         this.playerY[var2] = var11[1];
     }

--- a/client/src/main/java/com/aapeli/applet/AdCanvas.java
+++ b/client/src/main/java/com/aapeli/applet/AdCanvas.java
@@ -12,7 +12,8 @@ import java.awt.Toolkit;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.net.URL;
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 class AdCanvas extends Canvas implements MouseListener {
 
@@ -20,7 +21,7 @@ class AdCanvas extends Canvas implements MouseListener {
     private AApplet gameApplet;
     private LoadingPanel loadingPanel;
     private URL anURL117;
-    private Vector<AdCanvasText> aVector118;
+    private List<AdCanvasText> texts;
     private URL anURL119;
     private String aString120;
     private int anInt121;
@@ -31,10 +32,10 @@ class AdCanvas extends Canvas implements MouseListener {
     private long aLong126;
 
 
-    private AdCanvas(AApplet var1, URL var2, Vector<AdCanvasText> var3, URL var4, String var5, int var6) {
+    private AdCanvas(AApplet var1, URL var2, List<AdCanvasText> var3, URL var4, String var5, int var6) {
         this.gameApplet = var1;
         this.anURL117 = var2;
-        this.aVector118 = var3;
+        this.texts = var3;
         this.anURL119 = var4;
         this.aString120 = var5;
         this.anInt121 = var6;
@@ -60,10 +61,10 @@ class AdCanvas extends Canvas implements MouseListener {
                 }
 
                 var1.drawImage(this.anImage122, 0, 0, null);
-                int var5 = this.aVector118.size();
+                int var5 = this.texts.size();
 
                 for (int var6 = 0; var6 < var5; ++var6) {
-                    AdCanvasText var4 = this.aVector118.elementAt(var6);
+                    AdCanvasText var4 = this.texts.get(var6);
                     var4.method1548(var1);
                 }
             } else {
@@ -98,13 +99,13 @@ class AdCanvas extends Canvas implements MouseListener {
         try {
             String var2 = parameters.getParameter("ad_image");
             URL var3 = new URL(applet.getCodeBase(), var2);
-            Vector<AdCanvasText> var4 = new Vector<>();
+            List<AdCanvasText> var4 = new ArrayList<>();
 
             String var6;
             for (int var5 = 1; (var6 = parameters.getParameter("ad_text-" + var5)) != null; ++var5) {
                 AdCanvasText var7 = AdCanvasText.method1547(var6);
                 if (var7 != null) {
-                    var4.addElement(var7);
+                    var4.add(var7);
                 }
             }
 

--- a/client/src/main/java/com/aapeli/client/HtmlLine.java
+++ b/client/src/main/java/com/aapeli/client/HtmlLine.java
@@ -2,13 +2,14 @@ package com.aapeli.client;
 
 import java.awt.Font;
 import java.awt.Graphics;
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 class HtmlLine {
 
     private int anInt1366;
     private boolean aBoolean1367;
-    private Vector<HtmlWord> words;
+    private List<HtmlWord> words;
     private int nextWordStart;
     private int height;
     private final HtmlText aHtmlText1371;
@@ -18,7 +19,7 @@ class HtmlLine {
         this.aHtmlText1371 = htmlText;
         this.anInt1366 = var3;
         this.aBoolean1367 = var4;
-        this.words = new Vector<>();
+        this.words = new ArrayList<>();
         this.nextWordStart = 0;
         this.height = graphics.getFont().getSize();
     }
@@ -27,8 +28,8 @@ class HtmlLine {
         int wordsLength = this.words.size();
         String s = "[HtmlLine: words.size=" + wordsLength + "\n";
 
-        for (int i = 0; i < wordsLength; ++i) {
-            s = s + " " + this.words.elementAt(i).toString() + "\n";
+        for (HtmlWord word : this.words) {
+            s = s + " " + word.toString() + "\n";
         }
 
         s = s + "'relatx'=" + this.nextWordStart + " 'height'=" + this.height + "]";
@@ -42,7 +43,7 @@ class HtmlLine {
     protected void addWord(String text, Font font, int length) {
         if (!this.isEmpty() || text.trim().length() != 0) {
             HtmlWord word = new HtmlWord(this, text, font, this.nextWordStart, length);
-            this.words.addElement(word);
+            this.words.add(word);
             this.nextWordStart += length;
             int fontSize = font.getSize();
             if (fontSize > this.height) {
@@ -62,21 +63,19 @@ class HtmlLine {
 
     protected void draw(Graphics graphics, int x, int y) {
         int wordsCount = this.words.size();
-        HtmlWord word;
         int wordsLength;
         if (this.aBoolean1367) {
             wordsLength = 0;
 
-            for (int i = 0; i < wordsCount; ++i) {
-                word = this.words.elementAt(i);
-                wordsLength += word.getLength();
+            for (HtmlWord htmlWord : this.words) {
+                wordsLength += htmlWord.getLength();
             }
 
             x += (this.anInt1366 - wordsLength) / 2;
         }
 
         for (wordsLength = 0; wordsLength < wordsCount; ++wordsLength) {
-            word = this.words.elementAt(wordsLength);
+            HtmlWord word = this.words.get(wordsLength);
             word.draw(graphics, x, y);
         }
 

--- a/client/src/main/java/com/aapeli/client/HtmlText.java
+++ b/client/src/main/java/com/aapeli/client/HtmlText.java
@@ -1,21 +1,22 @@
 package com.aapeli.client;
 
 import java.awt.Graphics;
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 public class HtmlText {
 
-    private Vector<HtmlLine> lines;
-    public HtmlText(Graphics graphics, int var2, String var3) {
-        this.lines = this.method1589(graphics, var2, var3);
+    private List<HtmlLine> lines;
+    public HtmlText(Graphics graphics, int var2, String text) {
+        this.lines = this.createLines(graphics, var2, text);
     }
 
     public String toString() {
         int var1 = this.lines.size();
         String var2 = "[HtmlText: lines.size=" + var1 + "\n";
 
-        for (int var3 = 0; var3 < var1; ++var3) {
-            var2 = var2 + " " + this.lines.elementAt(var3).toString() + "\n";
+        for (HtmlLine line : this.lines) {
+            var2 = var2 + " " + line.toString() + "\n";
         }
 
         var2 = var2 + "]";
@@ -27,7 +28,7 @@ public class HtmlText {
         int var5 = 0;
 
         for (int var7 = 0; var7 < var4; ++var7) {
-            HtmlLine var6 = this.lines.elementAt(var7);
+            HtmlLine var6 = this.lines.get(var7);
             var5 = var6.getHeight() + 5;
             if (var7 > 0) {
                 var3 += var5;
@@ -39,46 +40,46 @@ public class HtmlText {
         return var3 + var5;
     }
 
-    private Vector<HtmlLine> method1589(Graphics var1, int var2, String var3) {
-        Class81 var4 = new Class81(this, var3, var1);
-        Vector<HtmlLine> var5 = new Vector<>();
+    private List<HtmlLine> createLines(Graphics g, int var2, String text) {
+        Class81 var4 = new Class81(this, text, g);
+        List<HtmlLine> lines = new ArrayList<>();
         boolean var6 = false;
-        HtmlLine line = new HtmlLine(this, var1, var2, var6);
+        HtmlLine line = new HtmlLine(this, g, var2, var6);
 
-        String var8;
-        while ((var8 = var4.method1611()) != null) {
-            if (var8.equals("<br>")) {
-                var5.addElement(line);
-                line = new HtmlLine(this, var1, var2, var6);
-            } else if (var8.equals("<center>")) {
+        String word;
+        while ((word = var4.method1611()) != null) {
+            if (word.equals("<br>")) {
+                lines.add(line);
+                line = new HtmlLine(this, g, var2, var6);
+            } else if (word.equals("<center>")) {
                 var6 = true;
-                line = this.method1590(line, var5, var1, var2, var6);
-            } else if (var8.equals("</center>")) {
+                line = this.method1590(line, lines, g, var2, var6);
+            } else if (word.equals("</center>")) {
                 var6 = false;
-                line = this.method1590(line, var5, var1, var2, var6);
+                line = this.method1590(line, lines, g, var2, var6);
             } else {
-                int var9 = var1.getFontMetrics().stringWidth(var8);
+                int var9 = g.getFontMetrics().stringWidth(word);
                 if (!line.method1604(var9)) {
-                    var5.addElement(line);
-                    line = new HtmlLine(this, var1, var2, var6);
+                    lines.add(line);
+                    line = new HtmlLine(this, g, var2, var6);
                 }
 
-                line.addWord(var8, var1.getFont(), var9);
+                line.addWord(word, g.getFont(), var9);
             }
         }
 
-        this.method1591(line, var5);
-        return var5;
+        this.method1591(line, lines);
+        return lines;
     }
 
-    private HtmlLine method1590(HtmlLine var1, Vector<HtmlLine> var2, Graphics var3, int var4, boolean var5) {
+    private HtmlLine method1590(HtmlLine var1, List<HtmlLine> var2, Graphics var3, int var4, boolean var5) {
         this.method1591(var1, var2);
         return new HtmlLine(this, var3, var4, var5);
     }
 
-    private void method1591(HtmlLine var1, Vector<HtmlLine> var2) {
+    private void method1591(HtmlLine var1, List<HtmlLine> var2) {
         if (!var1.isEmpty()) {
-            var2.addElement(var1);
+            var2.add(var1);
         }
 
     }

--- a/client/src/main/java/com/aapeli/client/ImageTracker.java
+++ b/client/src/main/java/com/aapeli/client/ImageTracker.java
@@ -5,8 +5,9 @@ import com.aapeli.tools.Tools;
 
 import java.applet.Applet;
 import java.awt.Image;
+import java.util.ArrayList;
 import java.util.Hashtable;
-import java.util.Vector;
+import java.util.List;
 
 class ImageTracker implements Runnable {
 
@@ -16,7 +17,7 @@ class ImageTracker implements Runnable {
     private Applet anApplet1396;
     private boolean aBoolean1397;
 
-    private Vector<ImageResource> imageResourceTable;
+    private List<ImageResource> imageResourceTable;
     private Hashtable<String, Image> imageTable;
     private AApplet anAApplet1400;
     private Thread aThread1401;
@@ -25,7 +26,7 @@ class ImageTracker implements Runnable {
     protected ImageTracker(Applet var1, boolean var2) {
         this.anApplet1396 = var1;
         this.aBoolean1397 = var2;
-        this.imageResourceTable = new Vector<>();
+        this.imageResourceTable = new ArrayList<>();
         this.imageTable = new Hashtable<>();
         this.anAApplet1400 = null;
         this.aBoolean1402 = false;
@@ -45,7 +46,7 @@ class ImageTracker implements Runnable {
         imageAlias = "N\t" + imageAlias;
         synchronized (this) {
             if (!this.containsResource(imageAlias)) {
-                this.imageResourceTable.addElement(new ImageResource(this, imageAlias, image));
+                this.imageResourceTable.add(new ImageResource(this, imageAlias, image));
             }
         }
     }
@@ -54,7 +55,7 @@ class ImageTracker implements Runnable {
         var1 = "S\t" + var1;
         synchronized (this) {
             if (!this.containsResource(var1)) {
-                this.imageResourceTable.insertElementAt(new ImageResource(this, var1, var2), 0);
+                this.imageResourceTable.addFirst(new ImageResource(this, var1, var2));
             }
         }
     }
@@ -63,7 +64,7 @@ class ImageTracker implements Runnable {
         var1 = "C\t" + var1;
         synchronized (this) {
             if (!this.containsResource(var1)) {
-                this.imageResourceTable.addElement(new ImageResource(this, var1, var2));
+                this.imageResourceTable.add(new ImageResource(this, var1, var2));
             }
         }
     }
@@ -159,7 +160,7 @@ class ImageTracker implements Runnable {
             } catch (Exception e) {}
         }
 
-        this.imageResourceTable.removeAllElements();
+        this.imageResourceTable.clear();
         this.imageResourceTable = null;
         this.anApplet1396 = null;
     }
@@ -211,10 +212,7 @@ class ImageTracker implements Runnable {
     }
 
     private synchronized ImageResource getImageResource(String var1) {
-        int var2 = this.imageResourceTable.size();
-
-        for (int var3 = 0; var3 < var2; ++var3) {
-            ImageResource var4 = this.imageResourceTable.elementAt(var3);
+        for (ImageResource var4 : this.imageResourceTable) {
             if (var4.method1648().equals(var1)) {
                 return var4;
             }
@@ -230,7 +228,7 @@ class ImageTracker implements Runnable {
                 return false;
             }
 
-            var1 = this.imageResourceTable.elementAt(0);
+            var1 = this.imageResourceTable.getFirst();
         }
 
         String imageAlias = var1.method1648();
@@ -276,9 +274,9 @@ class ImageTracker implements Runnable {
         int var2 = this.imageResourceTable.size();
 
         for (int var3 = 0; var3 < var2; ++var3) {
-            ImageResource var4 = this.imageResourceTable.elementAt(var3);
+            ImageResource var4 = this.imageResourceTable.get(var3);
             if (var4.method1648().equals(var1)) {
-                this.imageResourceTable.removeElementAt(var3);
+                this.imageResourceTable.remove(var3);
                 return var4;
             }
         }
@@ -289,7 +287,7 @@ class ImageTracker implements Runnable {
     private synchronized void method1647(String var1) {
         ImageResource var2 = this.method1646(var1);
         if (var2 != null && !var2.method1651()) {
-            this.imageResourceTable.addElement(var2);
+            this.imageResourceTable.add(var2);
         }
 
     }

--- a/client/src/main/java/com/aapeli/client/InputTextField.java
+++ b/client/src/main/java/com/aapeli/client/InputTextField.java
@@ -8,7 +8,8 @@ import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 public class InputTextField extends TextField implements FocusListener, KeyListener, ActionListener {
 
@@ -22,12 +23,12 @@ public class InputTextField extends TextField implements FocusListener, KeyListe
     private int anInt722;
     private boolean aBoolean723;
     private boolean enabled;
-    private Vector<String> userInputz;
+    private List<String> userInput;
     private int userInputzCount;
     private int anInt727;
     private String finalInput;
     private int inputTextLength;
-    private Vector<InputTextFieldListener> listeners;
+    private List<InputTextFieldListener> listeners;
 
 
     public InputTextField(int var1) {
@@ -52,7 +53,7 @@ public class InputTextField extends TextField implements FocusListener, KeyListe
         this.aBoolean723 = false;
         this.enabled = enabled;
         if (enabled) {
-            this.userInputz = new Vector<>();
+            this.userInput = new ArrayList<>();
             this.userInputzCount = this.anInt727 = 0;
         }
 
@@ -63,7 +64,7 @@ public class InputTextField extends TextField implements FocusListener, KeyListe
         this.addKeyListener(this);
         this.addActionListener(this);
         this.inputTextLength = 0;
-        this.listeners = new Vector<>();
+        this.listeners = new ArrayList<>();
     }
 
     public void focusGained(FocusEvent var1) {
@@ -87,7 +88,7 @@ public class InputTextField extends TextField implements FocusListener, KeyListe
         if (this.enabled) {
             int keyCode = evt.getKeyCode();
             if (keyCode == 38 || keyCode == 40) {
-                synchronized (this.userInputz) {
+                synchronized (this.userInput) {
                     if (this.userInputzCount == 0) {
                         return;
                     }
@@ -112,7 +113,7 @@ public class InputTextField extends TextField implements FocusListener, KeyListe
 
                     String var4;
                     if (this.anInt727 < this.userInputzCount) {
-                        var4 = this.userInputz.elementAt(this.anInt727);
+                        var4 = this.userInput.get(this.anInt727);
                     } else {
                         var4 = this.finalInput;
                     }
@@ -173,13 +174,13 @@ public class InputTextField extends TextField implements FocusListener, KeyListe
         }
 
         if (this.enabled) {
-            synchronized (this.userInputz) {
+            synchronized (this.userInput) {
                 if (this.userInputzCount >= 50) {
-                    this.userInputz.removeElementAt(0);
+                    this.userInput.remove(0);
                     --this.userInputzCount;
                 }
 
-                this.userInputz.addElement(userInput);
+                this.userInput.add(userInput);
                 ++this.userInputzCount;
                 this.anInt727 = this.userInputzCount;
             }
@@ -213,7 +214,7 @@ public class InputTextField extends TextField implements FocusListener, KeyListe
 
     public void addInputTextFieldListener(InputTextFieldListener listener) {
         synchronized (this) {
-            this.listeners.addElement(listener);
+            this.listeners.add(listener);
         }
     }
 

--- a/client/src/main/java/com/aapeli/client/StringDraw.java
+++ b/client/src/main/java/com/aapeli/client/StringDraw.java
@@ -6,7 +6,8 @@ import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics;
 import java.awt.Rectangle;
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 public class StringDraw {
 
@@ -69,7 +70,7 @@ public class StringDraw {
     public static int[] drawOutlinedStringWithMaxWidth(Graphics g, Color outlineColor, String text, int x, int y, int alignment, int maxWidth) {
         Font font = g.getFont();
         FontMetrics fontMetrics = g.getFontMetrics(font);
-        Vector<String> lines = createLines(fontMetrics, text, maxWidth);
+        List<String> lines = createLines(fontMetrics, text, maxWidth);
         int fontSize = font.getSize();
         int lineHeight = fontSize + (fontSize + 4) / 5;
         if (outlineColor != null) {
@@ -80,8 +81,8 @@ public class StringDraw {
         linesData[1] = linesData[0] * lineHeight;
         linesData[2] = 0;
 
-        for (int line = 0; line < linesData[0]; ++line) {
-            int lineWidth = drawOutlinedString(g, outlineColor, lines.elementAt(line), x, y, alignment);
+        for (String line: lines) {
+            int lineWidth = drawOutlinedString(g, outlineColor, line, x, y, alignment);
             if (lineWidth > linesData[2]) {
                 linesData[2] = lineWidth;
             }
@@ -113,25 +114,25 @@ public class StringDraw {
         return fontMetrics.stringWidth(text);
     }
 
-    public static Vector<String> createLines(Graphics g, String text, int maximumWidth) {
+    public static List<String> createLines(Graphics g, String text, int maximumWidth) {
         return createLines(g, g.getFont(), text, maximumWidth);
     }
 
-    public static Vector<String> createLines(Graphics g, Font font, String text, int maximumWidth) {
+    public static List<String> createLines(Graphics g, Font font, String text, int maximumWidth) {
         return createLines(g.getFontMetrics(font), text, maximumWidth);
     }
 
-    public static Vector<String> createLines(Component component, Font font, String text, int maximumWidth) {
+    public static List<String> createLines(Component component, Font font, String text, int maximumWidth) {
         return createLines(component.getFontMetrics(font), text, maximumWidth);
     }
 
-    public static Vector<String> createLines(FontMetrics fontMetrics, String text, int maximumWidth) {
-        Vector<String> lines = new Vector<>();
+    public static List<String> createLines(FontMetrics fontMetrics, String text, int maximumWidth) {
+        List<String> lines = new ArrayList<>();
         createLinesPrivate(lines, text, fontMetrics, maximumWidth);
         return lines;
     }
 
-    private static void createLinesPrivate(Vector<String> lines, String text, FontMetrics fontMetrics, int maximumWidth) {
+    private static void createLinesPrivate(List<String> lines, String text, FontMetrics fontMetrics, int maximumWidth) {
         String line = text;
         int linebreak = text.indexOf('\n');
         if (linebreak >= 0) {
@@ -149,7 +150,7 @@ public class StringDraw {
             }
         }
 
-        lines.addElement(line);
+        lines.add(line);
         int l = line.length();
         if (l < text.length()) {
             String newText = text.substring(l);

--- a/client/src/main/java/com/aapeli/colorgui/Choicer.java
+++ b/client/src/main/java/com/aapeli/colorgui/Choicer.java
@@ -10,14 +10,15 @@ import java.awt.event.ComponentEvent;
 import java.awt.event.ComponentListener;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 public class Choicer extends IPanel implements ComponentListener, ItemListener, ItemSelectable {
 
     private Choice choice = new Choice();
     private ColorSpinner colorSpinner;
     private boolean choiceMode = true;
-    private Vector<ItemListener> listeners;
+    private List<ItemListener> listeners;
     private Object synchronizationObject = new Object();
 
 
@@ -25,7 +26,7 @@ public class Choicer extends IPanel implements ComponentListener, ItemListener, 
         this.choice.setBackground(Color.white);
         this.choice.setForeground(Color.black);
         this.choice.addItemListener(this);
-        this.listeners = new Vector<>();
+        this.listeners = new ArrayList<>();
         this.setLayout(null);
         this.choice.setLocation(0, 0);
         this.add(this.choice);
@@ -55,7 +56,6 @@ public class Choicer extends IPanel implements ComponentListener, ItemListener, 
     }
 
     public void itemStateChanged(ItemEvent e) {
-        Vector<ItemListener> listeners = this.listeners;
         synchronized (this.listeners) {
             if (!this.listeners.isEmpty()) {
                 e = new ItemEvent(this, e.getID(), e.getItem(), e.getStateChange());
@@ -158,16 +158,14 @@ public class Choicer extends IPanel implements ComponentListener, ItemListener, 
     }
 
     public void addItemListener(ItemListener listener) {
-        Vector<ItemListener> listeners = this.listeners;
         synchronized (this.listeners) {
-            this.listeners.addElement(listener);
+            this.listeners.add(listener);
         }
     }
 
     public void removeItemListener(ItemListener var1) {
-        Vector<ItemListener> listeners = this.listeners;
         synchronized (this.listeners) {
-            this.listeners.removeElement(var1);
+            this.listeners.remove(var1);
         }
     }
 

--- a/client/src/main/java/com/aapeli/colorgui/ColorButton.java
+++ b/client/src/main/java/com/aapeli/colorgui/ColorButton.java
@@ -12,7 +12,8 @@ import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 public class ColorButton extends IPanel implements MouseMotionListener, MouseListener {
 
@@ -46,7 +47,7 @@ public class ColorButton extends IPanel implements MouseMotionListener, MouseLis
     private boolean aBoolean3277;
     private boolean aBoolean3278;
     private int anInt3279;
-    private Vector<ActionListener> aVector3280;
+    private List<ActionListener> listeners;
     private Image anImage3281;
     private Graphics aGraphics3282;
     private int anInt3283;
@@ -69,7 +70,7 @@ public class ColorButton extends IPanel implements MouseMotionListener, MouseLis
         this.aBoolean3276 = true;
         this.aBoolean3277 = this.aBoolean3278 = false;
         this.anInt3279 = 1;
-        this.aVector3280 = new Vector<>();
+        this.listeners = new ArrayList<>();
         this.aClass90_3285 = null;
         this.aBoolean3286 = false;
         this.addMouseMotionListener(this);
@@ -345,16 +346,14 @@ public class ColorButton extends IPanel implements MouseMotionListener, MouseLis
     }
 
     public void addActionListener(ActionListener var1) {
-        Vector<ActionListener> var2 = this.aVector3280;
-        synchronized (this.aVector3280) {
-            this.aVector3280.addElement(var1);
+        synchronized (this.listeners) {
+            this.listeners.add(var1);
         }
     }
 
     public void removeActionListener(ActionListener var1) {
-        Vector<ActionListener> var2 = this.aVector3280;
-        synchronized (this.aVector3280) {
-            this.aVector3280.removeElement(var1);
+        synchronized (this.listeners) {
+            this.listeners.remove(var1);
         }
     }
 
@@ -396,11 +395,10 @@ public class ColorButton extends IPanel implements MouseMotionListener, MouseLis
     }
 
     public void processActionEvent() {
-        Vector<ActionListener> var1 = this.aVector3280;
-        synchronized (this.aVector3280) {
-            if (this.aVector3280.size() != 0) {
+        synchronized (this.listeners) {
+            if (this.listeners.size() != 0) {
                 ActionEvent var2 = new ActionEvent(this, 1001, this.aString3272);
-                for (ActionListener listener : aVector3280) {
+                for (ActionListener listener : listeners) {
                     listener.actionPerformed(var2);
                 }
             }

--- a/client/src/main/java/com/aapeli/colorgui/ColorCheckbox.java
+++ b/client/src/main/java/com/aapeli/colorgui/ColorCheckbox.java
@@ -12,7 +12,8 @@ import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 public class ColorCheckbox extends IPanel implements ItemSelectable, MouseListener {
 
@@ -35,7 +36,7 @@ public class ColorCheckbox extends IPanel implements ItemSelectable, MouseListen
     private boolean aBoolean3302;
     private boolean aBoolean3303;
     private ColorCheckboxGroup aColorCheckboxGroup3304;
-    private Vector<ItemListener> aVector3305;
+    private List<ItemListener> listeners;
     private Image anImage3306;
     private Graphics aGraphics3307;
     private int anInt3308;
@@ -57,7 +58,7 @@ public class ColorCheckbox extends IPanel implements ItemSelectable, MouseListen
     public ColorCheckbox(String var1, boolean var2) {
         this.aString3300 = var1;
         this.aBoolean3302 = var2;
-        this.aVector3305 = new Vector<>();
+        this.listeners = new ArrayList<>();
         this.anInt3301 = -1;
         this.aBoolean3303 = false;
         this.setFont(FontConstants.font);
@@ -164,17 +165,15 @@ public class ColorCheckbox extends IPanel implements ItemSelectable, MouseListen
         }
     }
 
-    public void addItemListener(ItemListener var1) {
-        Vector<ItemListener> var2 = this.aVector3305;
-        synchronized (this.aVector3305) {
-            this.aVector3305.addElement(var1);
+    public void addItemListener(ItemListener listener) {
+        synchronized (this.listeners) {
+            this.listeners.add(listener);
         }
     }
 
-    public void removeItemListener(ItemListener var1) {
-        Vector<ItemListener> var2 = this.aVector3305;
-        synchronized (this.aVector3305) {
-            this.aVector3305.removeElement(var1);
+    public void removeItemListener(ItemListener listener) {
+        synchronized (this.listeners) {
+            this.listeners.remove(listener);
         }
     }
 
@@ -258,7 +257,7 @@ public class ColorCheckbox extends IPanel implements ItemSelectable, MouseListen
 
     public void setGroup(ColorCheckboxGroup var1) {
         this.aColorCheckboxGroup3304 = var1;
-        var1.method1747(this);
+        var1.addCheckbox(this);
         this.repaint();
     }
 
@@ -324,11 +323,10 @@ public class ColorCheckbox extends IPanel implements ItemSelectable, MouseListen
     }
 
     private void method838() {
-        Vector<ItemListener> var1 = this.aVector3305;
-        synchronized (this.aVector3305) {
-            if (this.aVector3305.size() != 0) {
+        synchronized (this.listeners) {
+            if (this.listeners.size() != 0) {
                 ItemEvent var2 = new ItemEvent(this, 0, this, 701);
-                for (ItemListener listener : aVector3305) {
+                for (ItemListener listener : listeners) {
                     listener.itemStateChanged(var2);
                 }
             }

--- a/client/src/main/java/com/aapeli/colorgui/ColorCheckboxGroup.java
+++ b/client/src/main/java/com/aapeli/colorgui/ColorCheckboxGroup.java
@@ -1,14 +1,16 @@
 package com.aapeli.colorgui;
 
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 public final class ColorCheckboxGroup {
 
-    private Vector<ColorCheckbox> aVector1553 = new Vector<>();
+    private List<ColorCheckbox> checkboxes = new ArrayList<>();
 
-
-    protected void method1747(ColorCheckbox var1) {
-        this.aVector1553.addElement(var1);
+    protected void addCheckbox(ColorCheckbox checkbox) {
+        synchronized(this.checkboxes) {
+            this.checkboxes.add(checkbox);
+        }
     }
 
     protected boolean method1748(boolean var1) {
@@ -21,7 +23,7 @@ public final class ColorCheckboxGroup {
     }
 
     private void method1749() {
-        for (ColorCheckbox colorCheckbox : aVector1553) {
+        for (ColorCheckbox colorCheckbox : checkboxes) {
             colorCheckbox.realSetState(false);
         }
     }

--- a/client/src/main/java/com/aapeli/colorgui/ColorList.java
+++ b/client/src/main/java/com/aapeli/colorgui/ColorList.java
@@ -16,7 +16,8 @@ import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 public final class ColorList extends Panel implements ComponentListener, AdjustmentListener, MouseListener, ItemSelectable {
 
@@ -50,8 +51,8 @@ public final class ColorList extends Panel implements ComponentListener, Adjustm
     private int sorting;
     private String title;
     private Color titleColor;
-    private Vector<ColorListItem> items;
-    private Vector<ColorListNode> nodes;
+    private List<ColorListItem> items;
+    private List<ColorListNode> nodes;
     private int lastMouseClickX;
     private int lastMouseClickY;
     private int rangeSelectionLastIndex;
@@ -61,7 +62,7 @@ public final class ColorList extends Panel implements ComponentListener, Adjustm
     private Graphics imageGraphics;
     private int imageWidth;
     private int imageHeight;
-    private Vector<ItemListener> listeners;
+    private List<ItemListener> listeners;
 
 
     public ColorList(int width, int height) {
@@ -84,7 +85,7 @@ public final class ColorList extends Panel implements ComponentListener, Adjustm
         int fontSize = font.getSize();
         this.fontBold = new Font(font.getName(), Font.BOLD, fontSize);
         this.iconWidth = iconWidth;
-        this.items = new Vector<>();
+        this.items = new ArrayList<>();
         this.selectable = 0;
         this.sorting = 0;
         this.rowHeight = (Math.max(fontSize, rowHeight)) + 4;
@@ -103,7 +104,7 @@ public final class ColorList extends Panel implements ComponentListener, Adjustm
         this.scrollbarVisible = false;
         this.addComponentListener(this);
         this.addMouseListener(this);
-        this.listeners = new Vector<>();
+        this.listeners = new ArrayList<>();
     }
 
     public void addNotify() {
@@ -132,12 +133,12 @@ public final class ColorList extends Panel implements ComponentListener, Adjustm
 
         ColorListItemGroup currentGroup = null;
         synchronized (this) {
-            this.nodes = new Vector<>();
+            this.nodes = new ArrayList<>();
             int y = 0;
             ColorListNode node;
             if (this.title != null) {
                 node = new ColorListNode(1, y, this.width - 2, this.rowHeight, this.iconWidth, this.backgroundImage != null, this.fontBold, this.titleColor, this.title, null);
-                this.nodes.addElement(node);
+                this.nodes.add(node);
                 node.draw(this.imageGraphics, this);
                 y += this.rowHeight;
             }
@@ -156,7 +157,7 @@ public final class ColorList extends Panel implements ComponentListener, Adjustm
                         ColorListItemGroup group = item.getGroup();
                         if (group != currentGroup) {
                             node = new ColorListNode(1, y, this.width - 2, this.rowHeight, this.iconWidth, this.backgroundImage != null, this.fontBold, Color.darkGray, group.getText(), group.getIcon());
-                            this.nodes.addElement(node);
+                            this.nodes.add(node);
                             node.draw(this.imageGraphics, this);
                             currentGroup = group;
                             y += this.rowHeight;
@@ -166,7 +167,7 @@ public final class ColorList extends Panel implements ComponentListener, Adjustm
                     }
 
                     node = new ColorListNode(1, y, this.width - 2, this.rowHeight, this.iconWidth, this.backgroundImage != null, this.font, this.fontBold, item);
-                    this.nodes.addElement(node);
+                    this.nodes.add(node);
                     node.draw(this.imageGraphics, this);
                     y += this.rowHeight;
                     ++itemIndex;
@@ -296,11 +297,11 @@ public final class ColorList extends Panel implements ComponentListener, Adjustm
     }
 
     public synchronized void addItemListener(ItemListener listener) {
-        this.listeners.addElement(listener);
+        this.listeners.add(listener);
     }
 
     public synchronized void removeItemListener(ItemListener listener) {
-        this.listeners.removeElement(listener);
+        this.listeners.remove(listener);
     }
 
     public Object[] getSelectedObjects() {
@@ -339,10 +340,10 @@ public final class ColorList extends Panel implements ComponentListener, Adjustm
                 newItems[i] = this.getItem(i);
             }
 
-            this.items.removeAllElements();
+            this.items.clear();
 
             for (int i = 0; i < itemsCount; ++i) {
-                this.items.insertElementAt(newItems[i], this.getPositionFor(newItems[i]));
+                this.items.add(this.getPositionFor(newItems[i]), newItems[i]);
             }
 
             this.repaint();
@@ -390,7 +391,7 @@ public final class ColorList extends Panel implements ComponentListener, Adjustm
     public synchronized void addItem(ColorListItem item) {
         item.setColorListReference(this);
         int position = this.getPositionFor(item);
-        this.items.insertElementAt(item, position);
+        this.items.add(position, item);
         int scrollbarValue = this.scrollbar.getValue();
         int scrollbarOffset = position < scrollbarValue ? 1 : 0;
         if (scrollbarOffset == 0 && scrollbarValue > 0 && scrollbarValue + this.scrollbar.getVisibleAmount() == this.scrollbar.getMaximum()) {
@@ -402,7 +403,7 @@ public final class ColorList extends Panel implements ComponentListener, Adjustm
     }
 
     public synchronized ColorListItem getItem(int i) {
-        return this.items.elementAt(i);
+        return this.items.get(i);
     }
 
     public synchronized ColorListItem getItem(String text) {
@@ -442,7 +443,7 @@ public final class ColorList extends Panel implements ComponentListener, Adjustm
     public synchronized ColorListItem removeItem(ColorListItem item) {
         int idx = this.items.indexOf(item);
         if (idx >= 0) {
-            this.items.removeElementAt(idx);
+            this.items.remove(idx);
             int scrollbarOffset = idx < this.scrollbar.getValue() ? -1 : 0;
             this.configureScrollbar(false, scrollbarOffset);
             this.repaint();
@@ -453,7 +454,7 @@ public final class ColorList extends Panel implements ComponentListener, Adjustm
 
     public synchronized void removeAllItems() {
         if (this.items.size() != 0) {
-            this.items.removeAllElements();
+            this.items.clear();
             this.configureScrollbar(false, 0);
             this.repaint();
         }
@@ -513,7 +514,7 @@ public final class ColorList extends Panel implements ComponentListener, Adjustm
             return null;
         } else {
             for (int i = 0; i < nodesCount; ++i) {
-                ColorListNode node = this.nodes.elementAt(i);
+                ColorListNode node = this.nodes.get(i);
                 if (node.containsYCoordinate(y)) {
                     return node.getItem();
                 }
@@ -562,7 +563,7 @@ public final class ColorList extends Panel implements ComponentListener, Adjustm
 
     private int getGroupStartPosition(int groupSortValue, int itemsCount) {
         for (int i = 0; i < itemsCount; ++i) {
-            int otherGroupSortValue = this.getGroupSortValue(this.items.elementAt(i));
+            int otherGroupSortValue = this.getGroupSortValue(this.items.get(i));
             if (groupSortValue <= otherGroupSortValue) {
                 return i;
             }
@@ -573,7 +574,7 @@ public final class ColorList extends Panel implements ComponentListener, Adjustm
 
     private int getNextGroupPosition(int groupSortValue, int groupPosition, int itemsCount) {
         for (int i = groupPosition; i < itemsCount; ++i) {
-            int sortValue = this.getGroupSortValue(this.items.elementAt(i));
+            int sortValue = this.getGroupSortValue(this.items.get(i));
             if (sortValue > groupSortValue) {
                 return i;
             }

--- a/client/src/main/java/com/aapeli/colorgui/ColorSpinner.java
+++ b/client/src/main/java/com/aapeli/colorgui/ColorSpinner.java
@@ -14,11 +14,12 @@ import java.awt.event.ItemListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 public final class ColorSpinner extends IPanel implements MouseListener, MouseMotionListener, ItemSelectable {
 
-    private Vector<String> aVector3310 = new Vector<>();
+    private List<String> items = new ArrayList<>();
     private int anInt3311 = -1;
     private int anInt3312 = 0;
     private boolean aBoolean3313;
@@ -26,7 +27,7 @@ public final class ColorSpinner extends IPanel implements MouseListener, MouseMo
     private boolean aBoolean3315;
     private Font aFont3316;
     private int anInt3317;
-    private Vector<ItemListener> aVector3318;
+    private List<ItemListener> listeners;
     private Image anImage3319;
     private Graphics aGraphics3320;
     private int anInt3321;
@@ -34,7 +35,6 @@ public final class ColorSpinner extends IPanel implements MouseListener, MouseMo
     private Class92 aClass92_3323;
     private int anInt3324;
     private Object anObject3325;
-    private static final String aString3326 = "Dialog";
 
 
     public ColorSpinner() {
@@ -45,7 +45,7 @@ public final class ColorSpinner extends IPanel implements MouseListener, MouseMo
         this.aClass92_3323 = null;
         this.anInt3324 = 0;
         this.anObject3325 = new Object();
-        this.aVector3318 = new Vector<>();
+        this.listeners = new ArrayList<>();
         this.addMouseListener(this);
         this.addMouseMotionListener(this);
         this.anInt3321 = this.anInt3322 = -1;
@@ -72,7 +72,7 @@ public final class ColorSpinner extends IPanel implements MouseListener, MouseMo
                 this.aGraphics3320.setColor(var5);
                 this.aGraphics3320.drawLine(0, var4 - 1, var3 - 1, var4 - 1);
                 this.aGraphics3320.setColor(this.method844(var5, var6));
-                double var7 = 1.0D * (double) (var3 - var4 * 2) / (double) this.aVector3310.size();
+                double var7 = 1.0D * (double) (var3 - var4 * 2) / (double) this.items.size();
                 this.aGraphics3320.drawLine((int) ((double) var4 + (double) this.anInt3311 * var7 + 0.5D), var4 - 2, (int) ((double) var4 + (double) (this.anInt3311 + 1) * var7 + 0.5D), var4 - 2);
             }
 
@@ -130,13 +130,12 @@ public final class ColorSpinner extends IPanel implements MouseListener, MouseMo
     }
 
     public void mousePressed(MouseEvent var1) {
-        Object var2 = this.anObject3325;
         synchronized (this.anObject3325) {
             Dimension var3 = this.getSize();
             int var4 = var3.width;
             int var5 = var3.height;
             int var6 = var1.getX();
-            int var7 = this.aVector3310.size();
+            int var7 = this.items.size();
             if (var6 < var5) {
                 --this.anInt3311;
                 if (this.anInt3311 < 0) {
@@ -184,11 +183,10 @@ public final class ColorSpinner extends IPanel implements MouseListener, MouseMo
     }
 
     public void mouseDragged(MouseEvent var1) {
-        Object var2 = this.anObject3325;
         synchronized (this.anObject3325) {
             if (this.aBoolean3314) {
                 Dimension var3 = this.getSize();
-                int var4 = this.aVector3310.size();
+                int var4 = this.items.size();
                 int var5 = (var1.getX() - var3.height) * var4 / (var3.width - var3.height * 2);
                 if (var5 < 0) {
                     var5 = 0;
@@ -212,33 +210,30 @@ public final class ColorSpinner extends IPanel implements MouseListener, MouseMo
     }
 
     public int addItem(String var1) {
-        Vector<String> var2 = this.aVector3310;
-        synchronized (this.aVector3310) {
-            this.aVector3310.addElement(var1);
+        synchronized (this.items) {
+            this.items.add(var1);
             if (this.anInt3311 == -1) {
                 this.anInt3311 = 0;
                 this.repaint();
             }
 
-            return this.aVector3310.size() - 1;
+            return this.items.size() - 1;
         }
     }
 
     public String getItem(int var1) {
-        Vector<String> var2 = this.aVector3310;
-        synchronized (this.aVector3310) {
-            return this.aVector3310.elementAt(var1);
+        synchronized (this.items) {
+            return this.items.get(var1);
         }
     }
 
     public String removeItem(int var1) {
-        Vector<String> var2 = this.aVector3310;
-        synchronized (this.aVector3310) {
-            String var3 = this.aVector3310.elementAt(var1);
-            this.aVector3310.removeElementAt(var1);
+        synchronized (this.items) {
+            String var3 = this.items.get(var1);
+            this.items.remove(var1);
             if (this.anInt3311 >= var1) {
                 --this.anInt3311;
-                if (this.anInt3311 == -1 && !this.aVector3310.isEmpty()) {
+                if (this.anInt3311 == -1 && !this.items.isEmpty()) {
                     this.anInt3311 = 0;
                 }
 
@@ -250,10 +245,9 @@ public final class ColorSpinner extends IPanel implements MouseListener, MouseMo
     }
 
     public boolean removeAllItems() {
-        Vector<String> var1 = this.aVector3310;
-        synchronized (this.aVector3310) {
-            if (!this.aVector3310.isEmpty()) {
-                this.aVector3310.removeAllElements();
+        synchronized (this.items) {
+            if (!this.items.isEmpty()) {
+                this.items.clear();
                 this.anInt3311 = -1;
                 this.repaint();
                 return true;
@@ -264,9 +258,8 @@ public final class ColorSpinner extends IPanel implements MouseListener, MouseMo
     }
 
     public boolean setSelectedIndex(int var1) {
-        Vector<String> var2 = this.aVector3310;
-        synchronized (this.aVector3310) {
-            if (var1 >= 0 && var1 < this.aVector3310.size()) {
+        synchronized (this.items) {
+            if (var1 >= 0 && var1 < this.items.size()) {
                 if (var1 != this.anInt3311) {
                     this.anInt3311 = var1;
                     this.repaint();
@@ -285,27 +278,24 @@ public final class ColorSpinner extends IPanel implements MouseListener, MouseMo
     }
 
     public String getSelectedItem() {
-        Vector<String> var1 = this.aVector3310;
-        synchronized (this.aVector3310) {
+        synchronized (this.items) {
             return this.anInt3311 == -1 ? null : this.getItem(this.anInt3311);
         }
     }
 
     public int getItemCount() {
-        return this.aVector3310.size();
+        return this.items.size();
     }
 
     public void addItemListener(ItemListener var1) {
-        Vector<ItemListener> var2 = this.aVector3318;
-        synchronized (this.aVector3318) {
-            this.aVector3318.addElement(var1);
+        synchronized (this.listeners) {
+            this.listeners.add(var1);
         }
     }
 
     public void removeItemListener(ItemListener var1) {
-        Vector<ItemListener> var2 = this.aVector3318;
-        synchronized (this.aVector3318) {
-            this.aVector3318.removeElement(var1);
+        synchronized (this.listeners) {
+            this.listeners.remove(var1);
         }
     }
 
@@ -379,9 +369,8 @@ public final class ColorSpinner extends IPanel implements MouseListener, MouseMo
     }
 
     private void method845() {
-        Vector<ItemListener> var1 = this.aVector3318;
-        synchronized (this.aVector3318) {
-            if (!this.aVector3318.isEmpty()) {
+        synchronized (this.listeners) {
+            if (!this.listeners.isEmpty()) {
                 if (this.aClass92_3323 != null) {
                     this.aClass92_3323.method1746();
                     this.aClass92_3323 = null;
@@ -401,7 +390,7 @@ public final class ColorSpinner extends IPanel implements MouseListener, MouseMo
         String var1 = this.getSelectedItem();
         if (var1 != null) {
             ItemEvent var2 = new ItemEvent(this, 701, var1, ItemEvent.SELECTED);
-            for (ItemListener listener : aVector3318) {
+            for (ItemListener listener : listeners) {
                 listener.itemStateChanged(var2);
             }
         }

--- a/client/src/main/java/com/aapeli/colorgui/ColorTextArea.java
+++ b/client/src/main/java/com/aapeli/colorgui/ColorTextArea.java
@@ -13,9 +13,10 @@ import java.awt.event.AdjustmentEvent;
 import java.awt.event.AdjustmentListener;
 import java.awt.event.ComponentEvent;
 import java.awt.event.ComponentListener;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.Vector;
+import java.util.List;
 
 public class ColorTextArea extends IPanel implements ComponentListener, AdjustmentListener {
 
@@ -49,8 +50,8 @@ public class ColorTextArea extends IPanel implements ComponentListener, Adjustme
     private int maxLineWidth;
     private int lineHeight;
     private int scrollWindowNumberOfLines;
-    private Vector<ColorText> lines;
-    private Vector<ColorText> texts;
+    private List<ColorText> lines;
+    private List<ColorText> texts;
     private Image image;
     private Graphics graphics;
     private int imageWidth;
@@ -75,8 +76,8 @@ public class ColorTextArea extends IPanel implements ComponentListener, Adjustme
         this.fontMetrics = this.getFontMetrics(font);
         this.fontSize = font.getSize();
         this.fontBold = new Font(font.getName(), Font.BOLD, font.getSize());
-        this.lines = new Vector<>();
-        this.texts = new Vector<>();
+        this.lines = new ArrayList<>();
+        this.texts = new ArrayList<>();
         this.backgroundImage = null;
         this.lineHeight = this.fontSize + 3;
         this.calculateLineStats();
@@ -120,7 +121,7 @@ public class ColorTextArea extends IPanel implements ComponentListener, Adjustme
                 int scrollbarOffset = this.hasScrollbar ? this.scrollbar.getValue() : 0;
 
                 for (int i = 0; i <= this.scrollWindowNumberOfLines && scrollbarOffset < linesCount; ++i) {
-                    ColorText colorText = this.lines.elementAt(scrollbarOffset);
+                    ColorText colorText = this.lines.get(scrollbarOffset);
                     if (!colorText.isTextEmpty()) {
                         this.graphics.setFont(colorText.isBold() ? this.fontBold : this.font);
                         this.graphics.setColor(colorText.getColor());
@@ -209,7 +210,7 @@ public class ColorTextArea extends IPanel implements ComponentListener, Adjustme
             String[] textWithTimestamps = new String[textCount];
             if (textCount > 0) {
                 for (int i = 0; i < textCount; ++i) {
-                    ColorText colorText = this.texts.elementAt(i);
+                    ColorText colorText = this.texts.get(i);
                     if (colorText.isTextEmpty()) {
                         textWithTimestamps[i] = "";
                     } else {
@@ -241,9 +242,9 @@ public class ColorTextArea extends IPanel implements ComponentListener, Adjustme
 
     private void reset(boolean clearText) {
         synchronized (this.synchronizationObject) {
-            this.lines.removeAllElements();
+            this.lines.clear();
             if (clearText) {
-                this.texts.removeAllElements();
+                this.texts.clear();
             }
 
             this.remove(this.scrollbar);
@@ -271,7 +272,7 @@ public class ColorTextArea extends IPanel implements ComponentListener, Adjustme
                     break;
                 }
 
-                ColorText colorText = this.texts.elementAt(i);
+                ColorText colorText = this.texts.get(i);
                 this.splitTextToLines(colorText.getColor(), colorText.getText(), colorText.isBold());
                 ++i;
             }
@@ -292,7 +293,7 @@ public class ColorTextArea extends IPanel implements ComponentListener, Adjustme
 
     private void addText(Color color, String text, boolean bold, boolean scrollToBottom) {
         synchronized (this.synchronizationObject) {
-            this.texts.addElement(new ColorText(color, text, bold));
+            this.texts.add(new ColorText(color, text, bold));
             int lineCount = this.lines.size();
             this.splitTextToLines(color, text, bold);
             this.updateScrollWindow(lineCount, scrollToBottom);
@@ -335,7 +336,7 @@ public class ColorTextArea extends IPanel implements ComponentListener, Adjustme
 
     private void addLine(Color color, String text, boolean bold) {
         synchronized (this.synchronizationObject) {
-            this.lines.addElement(new ColorText(color, text, bold));
+            this.lines.add(new ColorText(color, text, bold));
         }
     }
 

--- a/client/src/main/java/com/aapeli/colorgui/MultiColorList.java
+++ b/client/src/main/java/com/aapeli/colorgui/MultiColorList.java
@@ -16,7 +16,8 @@ import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 public class MultiColorList extends Panel implements AdjustmentListener, MouseListener, ItemSelectable {
 //todo refactor
@@ -58,14 +59,14 @@ public class MultiColorList extends Panel implements AdjustmentListener, MouseLi
     private int anInt703;
     private int[] anIntArray704;
     private int anInt705;
-    private Vector<MultiColorListItem> aVector706;
+    private List<MultiColorListItem> colorListItems;
     private int anInt707;
     private int anInt708;
     private int anInt709;
     private int anInt710;
     private Image anImage711;
     private Graphics aGraphics712;
-    private Vector<ItemListener> aVector713;
+    private List<ItemListener> listeners;
     private MultiColorListListener listListener;
 
     public MultiColorList(String[] var1, int[] var2, int var3, int var4, int var5) {
@@ -78,7 +79,7 @@ public class MultiColorList extends Panel implements AdjustmentListener, MouseLi
         this.aString694 = null;
         this.aChar695 = 46;
         this.anInt698 = var1 != null ? var1.length : 0;
-        this.aVector706 = new Vector<>();
+        this.colorListItems = new ArrayList<>();
         this.anInt705 = 0;
         this.anInt702 = var4 - 6 - 16;
         this.anInt703 = var5 / 16 - 1;
@@ -93,7 +94,7 @@ public class MultiColorList extends Panel implements AdjustmentListener, MouseLi
         this.aScrollbar686.setUnitIncrement(1);
         this.aBoolean687 = false;
         this.addMouseListener(this);
-        this.aVector713 = new Vector<>();
+        this.listeners = new ArrayList<>();
     }
 
     public void addNotify() {
@@ -119,7 +120,7 @@ public class MultiColorList extends Panel implements AdjustmentListener, MouseLi
         }
 
         this.anIntArray704 = null;
-        int var2 = this.aVector706.size();
+        int var2 = this.colorListItems.size();
         byte var3 = 14;
         byte var4 = var3;
         this.aGraphics712.setFont(aFont681);
@@ -203,7 +204,7 @@ public class MultiColorList extends Panel implements AdjustmentListener, MouseLi
     }
 
     public synchronized void mousePressed(MouseEvent evt) {
-        int var2 = this.aVector706.size();
+        int var2 = this.colorListItems.size();
         if (var2 != 0) {
             this.anInt707 = evt.getX();
             this.anInt708 = evt.getY();
@@ -303,11 +304,11 @@ public class MultiColorList extends Panel implements AdjustmentListener, MouseLi
     }
 
     public synchronized void addItemListener(ItemListener var1) {
-        this.aVector713.addElement(var1);
+        this.listeners.add(var1);
     }
 
     public synchronized void removeItemListener(ItemListener var1) {
-        this.aVector713.removeElement(var1);
+        this.listeners.remove(var1);
     }
 
     public Object[] getSelectedObjects() {
@@ -353,11 +354,11 @@ public class MultiColorList extends Panel implements AdjustmentListener, MouseLi
     }
 
     public int getItemCount() {
-        return this.aVector706.size();
+        return this.colorListItems.size();
     }
 
     public synchronized int getSelectedItemCount() {
-        int var1 = this.aVector706.size();
+        int var1 = this.colorListItems.size();
         int var2 = 0;
 
         for (int var3 = 0; var3 < var1; ++var3) {
@@ -383,7 +384,7 @@ public class MultiColorList extends Panel implements AdjustmentListener, MouseLi
         }
 
         int var3 = this.method957(var1);
-        this.aVector706.insertElementAt(var1, var3);
+        this.colorListItems.add(var3, var1);
         int var4 = this.aScrollbar686.getValue();
         int var5 = var3 < var4 ? 1 : 0;
         if (var5 == 0 && var4 + this.aScrollbar686.getVisibleAmount() == this.aScrollbar686.getMaximum()) {
@@ -395,11 +396,11 @@ public class MultiColorList extends Panel implements AdjustmentListener, MouseLi
     }
 
     public synchronized MultiColorListItem getItem(int var1) {
-        return this.aVector706.elementAt(var1);
+        return this.colorListItems.get(var1);
     }
 
     public synchronized MultiColorListItem getItem(int var1, String var2) {
-        int var3 = this.aVector706.size();
+        int var3 = this.colorListItems.size();
         if (var3 == 0) {
             return null;
         } else {
@@ -432,9 +433,9 @@ public class MultiColorList extends Panel implements AdjustmentListener, MouseLi
     }
 
     public synchronized void removeItem(MultiColorListItem var1) {
-        int var2 = this.aVector706.indexOf(var1);
+        int var2 = this.colorListItems.indexOf(var1);
         if (var2 >= 0) {
-            this.aVector706.removeElementAt(var2);
+            this.colorListItems.remove(var2);
             int var3 = var2 < this.aScrollbar686.getValue() ? -1 : 0;
             this.method955(var3);
             this.repaint();
@@ -443,15 +444,15 @@ public class MultiColorList extends Panel implements AdjustmentListener, MouseLi
     }
 
     public synchronized void removeAllItems() {
-        if (this.aVector706.size() != 0) {
-            this.aVector706.removeAllElements();
+        if (this.colorListItems.size() != 0) {
+            this.colorListItems.clear();
             this.method955(0);
             this.repaint();
         }
     }
 
     public synchronized void removeAllSelections() {
-        int var1 = this.aVector706.size();
+        int var1 = this.colorListItems.size();
 
         for (int var2 = 0; var2 < var1; ++var2) {
             this.getItem(var2).setSelected(false);
@@ -484,13 +485,13 @@ public class MultiColorList extends Panel implements AdjustmentListener, MouseLi
     }
 
     public synchronized void reSort() {
-        int var1 = this.aVector706.size();
+        int var1 = this.colorListItems.size();
         if (var1 != 0) {
             MultiColorListItem[] var2 = this.getAllItems();
-            this.aVector706.removeAllElements();
+            this.colorListItems.clear();
 
             for (int var3 = 0; var3 < var1; ++var3) {
-                this.aVector706.insertElementAt(var2[var3], this.method957(var2[var3]));
+                this.colorListItems.add(this.method957(var2[var3]), var2[var3]);
             }
 
             this.repaint();
@@ -516,7 +517,7 @@ public class MultiColorList extends Panel implements AdjustmentListener, MouseLi
     }
 
     private synchronized void method955(int var1) {
-        int var2 = this.aVector706.size();
+        int var2 = this.colorListItems.size();
         if (var2 <= this.anInt703) {
             if (this.aBoolean687) {
                 this.aScrollbar686.removeAdjustmentListener(this);
@@ -549,7 +550,7 @@ public class MultiColorList extends Panel implements AdjustmentListener, MouseLi
             return null;
         } else {
             MultiColorListItem[] var3 = new MultiColorListItem[var2];
-            int var4 = this.aVector706.size();
+            int var4 = this.colorListItems.size();
             int var5 = 0;
 
             for (int var7 = 0; var7 < var4; ++var7) {
@@ -565,7 +566,7 @@ public class MultiColorList extends Panel implements AdjustmentListener, MouseLi
     }
 
     private synchronized int method957(MultiColorListItem var1) {
-        int var2 = this.aVector706.size();
+        int var2 = this.colorListItems.size();
         if (var2 == 0) {
             return 0;
         } else if (this.anInt699 < 0) {
@@ -682,7 +683,7 @@ public class MultiColorList extends Panel implements AdjustmentListener, MouseLi
     }
 
     private int method960(int var1) {
-        int var2 = this.aVector706.size();
+        int var2 = this.colorListItems.size();
         if (var2 == 0) {
             return -1;
         } else {
@@ -701,7 +702,7 @@ public class MultiColorList extends Panel implements AdjustmentListener, MouseLi
     }
 
     private synchronized void method961(boolean var1) {
-        int var2 = this.aVector706.size();
+        int var2 = this.colorListItems.size();
 
         for (int var3 = 0; var3 < var2; ++var3) {
             this.getItem(var3).setSelected(var1);
@@ -711,9 +712,9 @@ public class MultiColorList extends Panel implements AdjustmentListener, MouseLi
     }
 
     private synchronized void method962(MultiColorListItem var1, int var2, int var3) {
-        if (this.aVector713.size() != 0) {
+        if (this.listeners.size() != 0) {
             ItemEvent var4 = new ItemEvent(this, var2, var1, var3);
-            for (ItemListener listener: this.aVector713) {
+            for (ItemListener listener: this.listeners) {
                 listener.itemStateChanged(var4);
             }
         }

--- a/client/src/main/java/com/aapeli/colorgui/RadioButtonGroup.java
+++ b/client/src/main/java/com/aapeli/colorgui/RadioButtonGroup.java
@@ -2,11 +2,12 @@ package com.aapeli.colorgui;
 
 import com.aapeli.client.IPanel;
 
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 public final class RadioButtonGroup {
 
-    private Vector<IPanel> aVector1589;
+    private List<IPanel> buttons;
     private boolean aBoolean1590;
 
 
@@ -15,16 +16,20 @@ public final class RadioButtonGroup {
     }
 
     public RadioButtonGroup(boolean var1) {
-        this.aVector1589 = new Vector<>();
+        this.buttons = new ArrayList<>();
         this.aBoolean1590 = var1;
     }
 
-    protected void method1756(RadioButton var1) {
-        this.aVector1589.addElement(var1);
+    protected void method1756(RadioButton button) {
+        synchronized (this.buttons) {
+            this.buttons.add(button);
+        }
     }
 
-    protected void method1757(RoundRadioButton var1) {
-        this.aVector1589.addElement(var1);
+    protected void method1757(RoundRadioButton button) {
+        synchronized (this.buttons) {
+            this.buttons.add(button);
+        }
     }
 
     protected boolean method1758(boolean var1) {
@@ -37,7 +42,7 @@ public final class RadioButtonGroup {
     }
 
     private void method1759() {
-        for (IPanel var2: this.aVector1589) {
+        for (IPanel var2: this.buttons) {
             if (var2 instanceof RadioButton) {
                 ((RadioButton) var2).realSetState(false);
             } else {

--- a/client/src/main/java/com/aapeli/colorgui/RoundButton.java
+++ b/client/src/main/java/com/aapeli/colorgui/RoundButton.java
@@ -12,7 +12,8 @@ import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 public class RoundButton extends IPanel implements MouseMotionListener, MouseListener {
 
@@ -32,7 +33,7 @@ public class RoundButton extends IPanel implements MouseMotionListener, MouseLis
     private Image anImage3392;
     private boolean aBoolean3393;
     private boolean aBoolean3394;
-    private Vector<ActionListener> aVector3395;
+    private List<ActionListener> listeners;
     private Image anImage3396;
     private Graphics aGraphics3397;
     private int anInt3398;
@@ -65,7 +66,7 @@ public class RoundButton extends IPanel implements MouseMotionListener, MouseLis
         this.anImage3391 = var2;
         this.anImage3392 = var3;
         this.aBoolean3393 = this.aBoolean3394 = false;
-        this.aVector3395 = new Vector<>();
+        this.listeners = new ArrayList<>();
         this.aClass95_3400 = null;
         this.aBoolean3401 = false;
         this.addMouseMotionListener(this);
@@ -216,16 +217,14 @@ public class RoundButton extends IPanel implements MouseMotionListener, MouseLis
     }
 
     public void addActionListener(ActionListener var1) {
-        Vector<ActionListener> var2 = this.aVector3395;
-        synchronized (this.aVector3395) {
-            this.aVector3395.addElement(var1);
+        synchronized (this.listeners) {
+            this.listeners.add(var1);
         }
     }
 
     public void removeActionListener(ActionListener var1) {
-        Vector<ActionListener> var2 = this.aVector3395;
-        synchronized (this.aVector3395) {
-            this.aVector3395.removeElement(var1);
+        synchronized (this.listeners) {
+            this.listeners.remove(var1);
         }
     }
 
@@ -258,11 +257,10 @@ public class RoundButton extends IPanel implements MouseMotionListener, MouseLis
     }
 
     public void processActionEvent() {
-        Vector<ActionListener> var1 = this.aVector3395;
-        synchronized (this.aVector3395) {
-            if (this.aVector3395.size() != 0) {
+        synchronized (this.listeners) {
+            if (this.listeners.size() != 0) {
                 ActionEvent var2 = new ActionEvent(this, 1001, this.aString3387);
-                for (ActionListener listener : aVector3395) {
+                for (ActionListener listener : listeners) {
                     listener.actionPerformed(var2);
                 }
             }

--- a/client/src/main/java/com/aapeli/colorgui/TabBar.java
+++ b/client/src/main/java/com/aapeli/colorgui/TabBar.java
@@ -12,7 +12,8 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.ComponentEvent;
 import java.awt.event.ComponentListener;
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 public class TabBar extends IPanel implements ComponentListener, ActionListener {
 
@@ -32,12 +33,12 @@ public class TabBar extends IPanel implements ComponentListener, ActionListener 
     private int anInt3416;
     private int anInt3417;
     private RadioButtonGroup aRadioButtonGroup3418;
-    private Vector<TabBarItem> aVector3419;
+    private List<TabBarItem> items;
     private int anInt3420;
     private int anInt3421;
     private int anInt3422;
     private int anInt3423;
-    private Vector<TabBarListener> aVector3424;
+    private List<TabBarListener> listeners;
     private Object anObject3425 = new Object();
 
 
@@ -52,11 +53,11 @@ public class TabBar extends IPanel implements ComponentListener, ActionListener 
         this.setButtonForeground(aColor3406);
         this.anInt3422 = 2;
         this.aRadioButtonGroup3418 = new RadioButtonGroup();
-        this.aVector3419 = new Vector<>();
+        this.items = new ArrayList<>();
         this.anInt3420 = 0;
         this.anInt3421 = -1;
         this.addComponentListener(this);
-        this.aVector3424 = new Vector<>();
+        this.listeners = new ArrayList<>();
         this.setLayout(null);
         this.anInt3423 = 0;
     }
@@ -200,7 +201,7 @@ public class TabBar extends IPanel implements ComponentListener, ActionListener 
     public void addTab(TabBarItem var1) {
         Object var2 = this.anObject3425;
         synchronized (this.anObject3425) {
-            this.aVector3419.addElement(var1);
+            this.items.add(var1);
             ++this.anInt3420;
             this.method877();
             RadioButton var3 = var1.getButton();
@@ -216,7 +217,7 @@ public class TabBar extends IPanel implements ComponentListener, ActionListener 
     }
 
     public TabBarItem getTabBarItemByIndex(int var1) {
-        TabBarItem var2 = this.aVector3419.elementAt(var1);
+        TabBarItem var2 = this.items.get(var1);
         return var2;
     }
 
@@ -238,7 +239,7 @@ public class TabBar extends IPanel implements ComponentListener, ActionListener 
         Object var1 = this.anObject3425;
         synchronized (this.anObject3425) {
             TabBarItem[] var2 = new TabBarItem[this.anInt3420];
-            this.aVector3419.copyInto(var2);
+            var2 = this.items.toArray(var2);
             return var2;
         }
     }
@@ -286,17 +287,15 @@ public class TabBar extends IPanel implements ComponentListener, ActionListener 
         this.repaint();
     }
 
-    public void addTabBarListener(TabBarListener var1) {
-        Object var2 = this.anObject3425;
+    public void addTabBarListener(TabBarListener listener) {
         synchronized (this.anObject3425) {
-            this.aVector3424.addElement(var1);
+            this.listeners.add(listener);
         }
     }
 
-    public void removeTabBarListener(TabBarListener var1) {
-        Object var2 = this.anObject3425;
+    public void removeTabBarListener(TabBarListener listener) {
         synchronized (this.anObject3425) {
-            this.aVector3424.removeElement(var1);
+            this.listeners.remove(listener);
         }
     }
 
@@ -380,8 +379,8 @@ public class TabBar extends IPanel implements ComponentListener, ActionListener 
     private void method879(int var1) {
         Object var2 = this.anObject3425;
         synchronized (this.anObject3425) {
-            if (this.aVector3424.size() != 0) {
-                for (TabBarListener tabBarListener : aVector3424) {
+            if (this.listeners.size() != 0) {
+                for (TabBarListener tabBarListener : listeners) {
                     tabBarListener.selectedTabChanged(var1);
                 }
             }

--- a/client/src/main/java/com/aapeli/connection/GamePacketQueue.java
+++ b/client/src/main/java/com/aapeli/connection/GamePacketQueue.java
@@ -1,14 +1,14 @@
 package com.aapeli.connection;
 
 import com.aapeli.tools.Tools;
-
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 class GamePacketQueue implements Runnable {
 
     private Connection conn;
     private ConnListener connListener;
-    private Vector<String> packets;
+    private List<String> packets;
     private boolean running;
     private Thread thread;
 
@@ -16,7 +16,7 @@ class GamePacketQueue implements Runnable {
     protected GamePacketQueue(Connection conn, ConnListener connListener) {
         this.conn = conn;
         this.connListener = connListener;
-        this.packets = new Vector<>();
+        this.packets = new ArrayList<>();
         this.running = true;
         this.thread = new Thread(this);
         this.thread.start();
@@ -45,7 +45,7 @@ class GamePacketQueue implements Runnable {
     }
 
     protected synchronized void addGamePacket(String command) {
-        this.packets.addElement(command);
+        this.packets.add(command);
     }
 
     protected void stop() {
@@ -54,9 +54,9 @@ class GamePacketQueue implements Runnable {
 
     private synchronized String nextGamePacket() {
         if (!this.packets.isEmpty() && this.running) {
-            String var1 = this.packets.elementAt(0);
-            this.packets.removeElementAt(0);
-            return var1;
+            String packet = this.packets.getFirst();
+            this.packets.removeFirst();
+            return packet;
         } else {
             return null;
         }

--- a/client/src/main/java/com/aapeli/connection/GameQueue.java
+++ b/client/src/main/java/com/aapeli/connection/GameQueue.java
@@ -1,10 +1,11 @@
 package com.aapeli.connection;
 
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 class GameQueue {
 
-    private Vector<String> commands = new Vector<>();
+    private List<String> commands = new ArrayList<>();
     private int count = 0;
     private ConnCipher connCipher = new ConnCipher((int) (Math.random() * 19.0D));
     protected long sendSeqNum;
@@ -15,24 +16,22 @@ class GameQueue {
         this.sendSeqNum = 0L;
     }
 
-    protected void add(String var1) {
-        long var2;
+    protected void add(String command) {
         synchronized (this) {
-            var2 = this.sendSeqNum++;
+            long sendSequenceNumber = this.sendSeqNum++;
+            command = this.connCipher.encrypt(sendSequenceNumber + " " + command);
+            this.commands.add(command);
         }
-
-        var1 = this.connCipher.encrypt(var2 + " " + var1);
-        this.commands.addElement(var1);
     }
 
     protected String pop() {
         if (this.commands.size() <= this.count) {
             return null;
         } else {
-            String var1 = this.commands.elementAt(this.count);
+            String var1 = this.commands.get(this.count);
             var1 = this.connCipher.decrypt(var1);
             if (this.commands.size() > 3) {
-                this.commands.removeElementAt(0);
+                this.commands.removeFirst();
             } else {
                 ++this.count;
             }

--- a/client/src/main/java/com/aapeli/multiuser/ChatBase.java
+++ b/client/src/main/java/com/aapeli/multiuser/ChatBase.java
@@ -22,7 +22,8 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.ComponentEvent;
 import java.awt.event.ComponentListener;
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 public abstract class ChatBase extends IPanel implements ComponentListener, UserListHandler, ActionListener, InputTextFieldListener {
 
@@ -52,7 +53,7 @@ public abstract class ChatBase extends IPanel implements ComponentListener, User
     public Component sayButton;
     public UrlLabel signupMessage;
     private String aString2357;
-    private Vector<ChatListener> chatListeners;
+    private List<ChatListener> chatListeners;
     private Object synchronizedObject;
 
     public ChatBase(Parameters parameters, TextManager textManager, ImageManager imageManager, BadWordFilter badWordFilter, boolean useSmallFont, boolean var6, int width, int height) {
@@ -77,7 +78,7 @@ public abstract class ChatBase extends IPanel implements ComponentListener, User
         this.chatDisabledStatus = 0;
         this.init(var5, var6, useSmallFont, var8, shouldNotWriteWelcomeMessage);
         this.addComponentListener(this);
-        this.chatListeners = new Vector<>();
+        this.chatListeners = new ArrayList<>();
     }
 
     public void update(Graphics g) {
@@ -192,12 +193,12 @@ public abstract class ChatBase extends IPanel implements ComponentListener, User
         this.repaint();
     }
 
-    public void addChatListener(ChatListener var1) {
-        this.chatListeners.addElement(var1);
+    public synchronized void addChatListener(ChatListener listener) {
+        this.chatListeners.add(listener);
     }
 
-    public void removeChatListener(ChatListener var1) {
-        this.chatListeners.removeElement(var1);
+    public synchronized void removeChatListener(ChatListener listener) {
+        this.chatListeners.remove(listener);
     }
 
     public void setMessageMaximumLength(int var1) {
@@ -610,7 +611,7 @@ public abstract class ChatBase extends IPanel implements ComponentListener, User
         ChatListener[] chatListeners = new ChatListener[chatListenersCount];
 
         for (int i = 0; i < chatListenersCount; ++i) {
-            chatListeners[i] = this.chatListeners.elementAt(i);
+            chatListeners[i] = this.chatListeners.get(i);
         }
 
         return chatListeners;

--- a/client/src/main/java/com/aapeli/multiuser/UserList.java
+++ b/client/src/main/java/com/aapeli/multiuser/UserList.java
@@ -27,9 +27,10 @@ import java.awt.event.ComponentListener;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Hashtable;
+import java.util.List;
 import java.util.StringTokenizer;
-import java.util.Vector;
 
 public class UserList extends IPanel implements ComponentListener, ItemListener, ActionListener {
 
@@ -81,8 +82,8 @@ public class UserList extends IPanel implements ComponentListener, ItemListener,
     private MenuItem adminBroadcastMessageMenuItem;
     private User selectedUser;
     private StaffActionFrame staffActionFrame;
-    private Vector<String> privateMessageUsers;
-    private Vector<String> ignoredUsers;
+    private List<String> privateMessageUsers;
+    private List<String> ignoredUsers;
     private boolean sheriffMarkEnabled;
     private boolean dimmerNicksEnabled;
     private ColorTextArea chatOutput;
@@ -114,8 +115,8 @@ public class UserList extends IPanel implements ComponentListener, ItemListener,
         this.rightClickMenuEnabled = false;
         this.sheriffStatus = 0;
         this.adminStatus = 0;
-        this.privateMessageUsers = new Vector<>();
-        this.ignoredUsers = new Vector<>();
+        this.privateMessageUsers = new ArrayList<>();
+        this.ignoredUsers = new ArrayList<>();
         this.sheriffMarkEnabled = true;
         this.dimmerNicksEnabled = true;
         this.languages = new Languages(textManager, imageManager);
@@ -828,18 +829,18 @@ public class UserList extends IPanel implements ComponentListener, ItemListener,
         }
     }
 
-    private void removeUser(User user) {
+    private synchronized void removeUser(User user) {
         String nick = user.getNick();
         if (user.isGettingPrivateMessages()) {
-            this.privateMessageUsers.addElement(nick);
+            this.privateMessageUsers.add(nick);
         } else {
-            this.privateMessageUsers.removeElement(nick);
+            this.privateMessageUsers.remove(nick);
         }
 
         if (user.isIgnore()) {
-            this.ignoredUsers.addElement(nick);
+            this.ignoredUsers.add(nick);
         } else {
-            this.ignoredUsers.removeElement(nick);
+            this.ignoredUsers.remove(nick);
         }
 
     }

--- a/client/src/main/java/com/aapeli/tools/QuickTimer.java
+++ b/client/src/main/java/com/aapeli/tools/QuickTimer.java
@@ -1,11 +1,12 @@
 package com.aapeli.tools;
 
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 public class QuickTimer implements Runnable {
 
     private int anInt1727;
-    private Vector<QuickTimerListener> aVector1728;
+    private List<QuickTimerListener> listeners;
     private boolean stopped;
     private static final String aString1730 = "QuickTimer.start() called after QuickTimer.stopAll() was called";
 
@@ -20,7 +21,7 @@ public class QuickTimer implements Runnable {
 
     private QuickTimer(int var1, QuickTimerListener var2, boolean var3) {
         this.anInt1727 = var1;
-        this.aVector1728 = new Vector<>();
+        this.listeners = new ArrayList<>();
         if (var2 != null) {
             this.addListener(var2);
         }
@@ -39,7 +40,7 @@ public class QuickTimer implements Runnable {
     public void run() {
         Tools.sleep(this.anInt1727);
         if (!this.stopped) {
-            for (QuickTimerListener var2: this.aVector1728) {
+            for (QuickTimerListener var2: this.listeners) {
                 if (var2 != null) {
                     var2.qtFinished();
                 }
@@ -48,12 +49,16 @@ public class QuickTimer implements Runnable {
         }
     }
 
-    public void addListener(QuickTimerListener var1) {
-        this.aVector1728.addElement(var1);
+    public void addListener(QuickTimerListener listener) {
+        synchronized (this.listeners) {
+            this.listeners.add(listener);
+        }
     }
 
-    public void removeListener(QuickTimerListener var1) {
-        this.aVector1728.removeElement(var1);
+    public void removeListener(QuickTimerListener listener) {
+        synchronized (this.listeners) {
+            this.listeners.remove(listener);
+        }
     }
 
     public void start() {

--- a/client/src/main/java/com/aapeli/tools/Tools.java
+++ b/client/src/main/java/com/aapeli/tools/Tools.java
@@ -4,8 +4,8 @@ import java.awt.Color;
 import java.awt.Component;
 import java.awt.Graphics;
 import java.util.Calendar;
+import java.util.List;
 import java.util.StringTokenizer;
-import java.util.Vector;
 
 public class Tools {
 
@@ -110,21 +110,6 @@ public class Tools {
             }
 
             return -1;
-        }
-    }
-
-    public static <E> String[] vectorToStringArray(Vector<E> var0) {
-        if (var0 == null) {
-            return null;
-        } else {
-            int var1 = var0.size();
-            String[] var2 = new String[var1];
-
-            for (int var3 = 0; var3 < var1; ++var3) {
-                var2[var3] = var0.elementAt(var3).toString();
-            }
-
-            return var2;
         }
     }
 

--- a/client/src/main/java/com/aapeli/tools/XmlUnit.java
+++ b/client/src/main/java/com/aapeli/tools/XmlUnit.java
@@ -1,8 +1,9 @@
 package com.aapeli.tools;
 
+import java.util.ArrayList;
 import java.util.Hashtable;
+import java.util.List;
 import java.util.Stack;
-import java.util.Vector;
 
 public class XmlUnit {
 
@@ -10,14 +11,14 @@ public class XmlUnit {
     private static final String aString1736 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-:";
     private String name;
     private String value;
-    private Vector<XmlUnit> children;
+    private List<XmlUnit> children;
     private Hashtable<String, String> attributes;
 
 
     private XmlUnit(String var1) {
         this.name = var1;
         this.value = null;
-        this.children = new Vector<>();
+        this.children = new ArrayList<>();
         this.attributes = new Hashtable<>();
     }
 
@@ -40,10 +41,7 @@ public class XmlUnit {
 
     public XmlUnit getChild(String name) {
         synchronized (this.children) {
-            int childrenCount = this.children.size();
-
-            for (int index = 0; index < childrenCount; ++index) {
-                XmlUnit child = this.children.elementAt(index);
+            for (XmlUnit child : this.children) {
                 if (child.getName().equals(name)) {
                     return child;
                 }
@@ -64,7 +62,7 @@ public class XmlUnit {
             XmlUnit[] childrenArray = new XmlUnit[childrenCount];
 
             for (int index = 0; index < childrenCount; ++index) {
-                childrenArray[index] = this.children.elementAt(index);
+                childrenArray[index] = this.children.get(index);
             }
 
             return childrenArray;
@@ -351,7 +349,7 @@ public class XmlUnit {
 
     private XmlUnit addChild(XmlUnit var1) {
         synchronized (this.children) {
-            this.children.addElement(var1);
+            this.children.add(var1);
             return this;
         }
     }


### PR DESCRIPTION
ArrayLists come with a nice 20-30% performance boost and are the preferred way of dealing with ordered collections in modern Java, see https://stackoverflow.com/q/2986296 for more information.

Unlike Vectors, they are not internally synchronized which means the code has to be audited for structural modifications to the ArrayLists and those places have to be explicitly synchronized if they are called by multiple threads.

For each class that used Vectors, I checked that it is safe to convert them to ArrayLists (i.e. all methods that modify the collection that can be called from multiple threads are synchronized):
- AdCanvas -- `texts` is only modified in the `create` method, which is only called once from `run` in AApplet so there's no need for synchronization.
- ChatBase -- added synchronization to methods that modify `chatListeners`.
- Choicer -- only modifies `listeners` in synchronized blocks.
- ColorButton -- only modifies `listeners` in synchronized blocks.
- ColorCheckbox -- access to `listeners` only happens in synchronized blocks.
- ColorCheckboxGroup -- added synchronization around `addCheckbox` method.
- ColorList -- `nodes` is only modified in synchronized blocks. `items` and `listeners` are modified only in synchronized methods.
- ColorSpinner -- `items` and `listeners` only modified in synchronized blocks.
- ColorTextArea -- `lines` and `texts` are only modified in synchronized blocks.
- Connection -- added synchronization around `thriftLogs` modification.
- GameCanvas -- `teleportStarts` and `teleportExists` are only modified in `init` method called once for every track so there's no need for synchronization.
- GamePacketQueue -- access to `packets` only happens in synchronized methods.
- GameQueue -- added synchronization for `commands` modification in `add` method. `pop` is only called from the `run` function of `Connection` so it does not need synchronization.
- HackedShot -- `teleportStarts` and `teleportExits` are never modified, no need for synchronization.
- HtmlLine -- `words` is only modified from `createLines` in `HtmlText` which is only called from its constructor so there is no need for synchronization.
- HtmlText -- `lines` is only modified in `createLines`, which is only called from the constructor, so there is no need for synchronization.
- ImageTracker -- all access to `imageResourceTable` is synchronized except for `removeAllImageResources` which is only called once when the applet is destroyed so there's no need for synchronization.
- InputTextField -- `userInput` and `listeners` are only modified in synchronized blocks.
- MultiColorList -- `colorListItems` and `listeners` are only modified in synchronized methods.
- QuickTimer -- added synchronization to the methods that modify `listeners`.
- RadioButtonGroup -- added synchronization to methods that modify `buttons`.
- RoundButton -- access to `listeners` only happens in synchronized blocks.
- StringDraw -- `Vector` was not used for any state, only to store intermediate results. No need for synchronization.
- TabBar -- `listeners` and `items` are only modified in synchronized blocks.
- Tools -- did not modify the `Vector`, no synchronization needed.
- UserList -- added synchronization to methods that modify `privateMessageUsers` and `ignoredUsers`.
- XmlUnit -- all access to `children` happens in synchronized blocks.

In general, I mostly replicated the synchronization from the previous behavior with Vector which might result in some unnecessary synchronization but since the client is not performance-critical, it's not too bad to over-synchronize.